### PR TITLE
updated point_os1.h to match PCL pointXYZI definition

### DIFF
--- a/ouster_ros/include/ouster_ros/point_os1.h
+++ b/ouster_ros/include/ouster_ros/point_os1.h
@@ -7,9 +7,9 @@ namespace OS1 {
 
 struct EIGEN_ALIGN16 PointOS1 {
     PCL_ADD_POINT4D;
+    float intensity;
     float t;
     uint16_t reflectivity;
-    uint16_t intensity;
     uint8_t ring;
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
@@ -20,9 +20,9 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::OS1::PointOS1,
     (float, x, x)
     (float, y, y)
     (float, z, z)
+    (float, intensity, intensity)
     (float, t, t)
     (uint16_t, reflectivity, reflectivity)
-    (uint16_t, intensity, intensity)
     (uint8_t, ring, ring)
 )
 


### PR DESCRIPTION
The pcl fromROSMsg() function converts a ROS PointCloud2 message to a PCL PointXYZI point cloud. PCL expects the ROS PC2 message to be formatted similar to the  [PointXYZI](https://github.com/PointCloudLibrary/pcl/blob/master/common/include/pcl/point_types.h).

The from ROSMsg() expects the third field in the ROS PC2 message to be the intensity field and it expects the filed to be a float. The function throws a warning otherwise. This change mitigates the warning to enable the intensity information to be transferred to the PointXYZI variable in addition to the x, y, and z information.