### PR TITLE
Handle tf_prefix correctly

### DIFF
--- a/ouster_ros/os1.launch
+++ b/ouster_ros/os1.launch
@@ -9,6 +9,7 @@
   <arg name="metadata" default="" doc="override default metadata file for replays"/>
   <arg name="viz" default="false" doc="whether to run a simple visualizer"/>
   <arg name="image" default="false" doc="publish range/intensity/noise image topic"/>
+  <arg name="tf_prefix" default="" doc="namespace for tf transforms"/>
 
   <node pkg="ouster_ros" name="os1_node" type="os1_node" output="screen" required="true">
     <param name="~/lidar_mode" type="string" value="$(arg lidar_mode)"/>
@@ -24,6 +25,7 @@
     <remap from="~/os1_config" to="/os1_node/os1_config"/>
     <remap from="~/lidar_packets" to="/os1_node/lidar_packets"/>
     <remap from="~/imu_packets" to="/os1_node/imu_packets"/>
+    <param name="~/tf_prefix" value="$(arg tf_prefix)"/>
   </node>
 
   <node if="$(arg viz)" pkg="ouster_ros" name="viz_node" type="viz_node" output="screen" required="true">

--- a/ouster_ros/src/os1_cloud_node.cpp
+++ b/ouster_ros/src/os1_cloud_node.cpp
@@ -28,9 +28,12 @@ int main(int argc, char** argv) {
     ros::NodeHandle nh("~");
 
     auto tf_prefix = nh.param("tf_prefix", std::string{});
-    auto sensor_frame = tf_prefix + "/os1_sensor";
-    auto imu_frame = tf_prefix + "/os1_imu";
-    auto lidar_frame = tf_prefix + "/os1_lidar";
+    if (!tf_prefix.empty()) {
+      if (tf_prefix.back() != '/') tf_prefix.append(1, '/');
+    }
+    auto sensor_frame = tf_prefix + "os1_sensor";
+    auto imu_frame = tf_prefix + "os1_imu";
+    auto lidar_frame = tf_prefix + "os1_lidar";
 
     ouster_ros::OS1ConfigSrv cfg{};
     auto client = nh.serviceClient<ouster_ros::OS1ConfigSrv>("os1_config");


### PR DESCRIPTION
This pr handles two issues with tf_prefix:
- tf_prefix is dealt with in the code of os1_cloud_node.cpp, but not set in the default launch file
- tf_prefix is deprecated by ROS [http://wiki.ros.org/tf2/Migration#Removal_of_support_for_tf_prefix](url). This creates problems with some packages that assert that frame names do not start with / (e.g. [https://github.com/googlecartographer/cartographer_ros](url) )

For my use case it would be sufficient to remove the leading / in the frame names, or to get rid of tf_prefix altogether, but this pr maintains the old behaviour for users that might depend on it.

Hope this is helpful. In any case, let me say that I find ouster driver and documentation very good and usable compared to others I dealt with in the past.