### PR TITLE
Turn on Position Independent Code

### DIFF
--- a/ouster_client/CMakeLists.txt
+++ b/ouster_client/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 add_library(ouster_client STATIC
   src/os1.cpp
   src/os1_util.cpp)
+set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(ouster_client jsoncpp)
 target_include_directories(ouster_client PUBLIC include)
 target_include_directories(ouster_client SYSTEM PRIVATE ${jsoncpp_INCLUDE_DIRS})

--- a/ouster_ros/CMakeLists.txt
+++ b/ouster_ros/CMakeLists.txt
@@ -43,6 +43,7 @@ catkin_package(
 )
 
 add_library(ouster_ros STATIC src/os1_ros.cpp)
+set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(ouster_ros ${catkin_LIBRARIES})
 add_dependencies(ouster_ros ${PROJECT_NAME}_gencpp)
 


### PR DESCRIPTION
When incorporating an Ouster lidar in my lidar stack, I would like to use existing ouster libraries in my nodelets. To this end I needed to turn on Position Independent Code so that I could build dynamic libraries.