### PR TITLE
Use iterator_traits to access value_type so that raw pointers work

### DIFF
--- a/ouster_client/include/ouster/os1_util.h
+++ b/ouster_client/include/ouster/os1_util.h
@@ -82,7 +82,7 @@ std::vector<int> get_px_offset(int W);
 template <typename iterator_type, typename F, typename C>
 std::function<void(const uint8_t*, iterator_type it)> batch_to_iter(
     const std::vector<double>& xyz_lut, int W, int H,
-    const typename iterator_type::value_type& empty, C&& c, F&& f) {
+    const typename std::iterator_traits<iterator_type>::value_type& empty, C&& c, F&& f) {
     int next_m_id{W};
     int32_t cur_f_id{-1};
 


### PR DESCRIPTION
See: https://en.cppreference.com/w/cpp/iterator/iterator_traits

>This type trait may be specialized for user-provided types that may be used as iterators. The standard library provides two partial specializations for pointer types T*, which makes it possible to use all iterator-based algorithms with raw pointers.

This allows for using a raw pointer type as well as a random access iterator for `typename iterator_type`