### PR TITLE
Extended internal UDP socket buffer size

### DIFF
--- a/ouster_client/src/os1.cpp
+++ b/ouster_client/src/os1.cpp
@@ -80,6 +80,12 @@ int udp_data_socket(int port) {
             continue;
         }
 
+        int recv_buf_size = 10 * 1024 * 1024; // 10MB
+        if (setsockopt(sock_fd, SOL_SOCKET, SO_RCVBUF, &recv_buf_size, sizeof(recv_buf_size)) == -1) {
+        	std::cerr << "udp setsockopt(SO_RCVBUF): " << std::strerror(errno) << std::endl;
+            continue;
+        }
+
         break;
     }
 


### PR DESCRIPTION
Time to time, we watched black vertical stripes in ouster visualizer. After making some research, we have found that the problem was with lost UDP packets. OS-1-64 has very intensive traffic (according to documentation: 1280 packets/sec, packet size = 12608 Bytes). By default, Linux has small size of UDP receive buffer = 212992 Bytes that means it can accommodate only 16 Ouster packets. Compare it with 1280 packets/sec speed. If receive buffer is overflowed, oldest packets are dropped by the system. 

It is proposed to increase size of UDP receive buffer. This will allow to keep UDP packets from being deleted by the system at peak times. In our case, this approach completely solved the problem. UDP receive buffer can be enlarged either for entire system or for specific socket. I think, second approach is preferable.