### PR TITLE
Msg Timestamps - switch from sim_time to ros_time

### DIFF
--- a/ouster_ros/src/os1_ros.cpp
+++ b/ouster_ros/src/os1_ros.cpp
@@ -30,7 +30,7 @@ sensor_msgs::Imu packet_to_imu_msg(const PacketMsg& p,
     sensor_msgs::Imu m;
     const uint8_t* buf = p.buf.data();
     
-    //-----To support Unix/Pisix time stamp -------
+    //-----To support Unix/Posix time stamp -------
     //m.header.stamp.fromNSec(imu_gyro_ts(buf)); 
     m.header.stamp = ros::Time::now();
     //---------------------------------------------
@@ -69,7 +69,7 @@ sensor_msgs::PointCloud2 cloud_to_cloud_msg(const CloudOS1& cloud, ns timestamp,
     pcl::toROSMsg(cloud, msg);
     msg.header.frame_id = frame;
 
-    //-----To support Unix/Pisix time stamp -------
+    //-----To support Unix/Posix time stamp -------
     //msg.header.stamp.fromNSec(timestamp.count());
     msg.header.stamp = ros::Time::now();
     //---------------------------------------------

--- a/ouster_ros/src/os1_ros.cpp
+++ b/ouster_ros/src/os1_ros.cpp
@@ -29,8 +29,12 @@ sensor_msgs::Imu packet_to_imu_msg(const PacketMsg& p,
     const double standard_g = 9.80665;
     sensor_msgs::Imu m;
     const uint8_t* buf = p.buf.data();
-
-    m.header.stamp.fromNSec(imu_gyro_ts(buf));
+    
+    //-----To support Unix/Pisix time stamp -------
+    //m.header.stamp.fromNSec(imu_gyro_ts(buf)); 
+    m.header.stamp = ros::Time::now();
+    //---------------------------------------------
+    
     m.header.frame_id = frame;
 
     m.orientation.x = 0;
@@ -64,7 +68,12 @@ sensor_msgs::PointCloud2 cloud_to_cloud_msg(const CloudOS1& cloud, ns timestamp,
     sensor_msgs::PointCloud2 msg{};
     pcl::toROSMsg(cloud, msg);
     msg.header.frame_id = frame;
-    msg.header.stamp.fromNSec(timestamp.count());
+
+    //-----To support Unix/Pisix time stamp -------
+    //msg.header.stamp.fromNSec(timestamp.count());
+    msg.header.stamp = ros::Time::now();
+    //---------------------------------------------
+    
     return msg;
 }
 


### PR DESCRIPTION
The timestamps of both cloud and IMU packets supported by repo include `sim_time` which is not well-supported by Autoware and ROS topic synchronization in multi sensor environments. 

This change forces the sensor packets to use ros_time in the form of Unix/Posix timestamps.