### PR TITLE
Update the eigen build_depend tag in ouster_ros package.xml

### DIFF
--- a/ouster_ros/package.xml
+++ b/ouster_ros/package.xml
@@ -8,7 +8,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>libjsoncpp</build_depend>
-  <build_depend>libeigen3</build_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>


### PR DESCRIPTION
Update the eigen build_depend in `ouster_ros` to correctly reflect what is in the rosdep base: https://github.com/ros/rosdistro/blob/1a9fda299e71f1b0dbe670516420fb05986b7214/rosdep/base.yaml#L667-L685