### PR TITLE
Clean up dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,12 +34,15 @@ Building on Linux / macOS
 
 To install build dependencies on Ubuntu, run::
 
-    sudo apt install build-essential cmake libglfw3-dev libglew-dev libeigen3-dev \
-         libjsoncpp-dev libtclap-dev
+    sudo apt install build-essential cmake
 
 On macOS, install XCode and `homebrew <https://brew.sh>`_ and run::
 
-    brew install cmake pkg-config glfw glew eigen jsoncpp tclap
+    brew install cmake pkg-config
+
+Then install further dependencies with `rosdep`::
+
+    rosdep install --from-paths <path to ouster_example>
 
 To build run the following commands::
 

--- a/ouster_ros/package.xml
+++ b/ouster_ros/package.xml
@@ -7,27 +7,27 @@
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>libjsoncpp</build_depend>
-  <build_depend>libeigen3</build_depend>
-  <build_depend>roscpp</build_depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>pcl_ros</depend>
+
+  <build_depend>libjsoncpp-dev</build_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>pcl_ros</build_depend>
   <build_depend>pcl_conversions</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
-  
+  <build_depend>libglew-dev</build_depend>
+  <build_depend>libglfw3-dev</build_depend>
+  <build_depend>libtclap-dev</build_depend>
+
   <exec_depend>libjsoncpp</exec_depend>
-  <exec_depend>roscpp</exec_depend>
   <exec_depend>message_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>pcl_ros</exec_depend>
   <exec_depend>pcl_conversions</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
 
   <export></export>
 </package>


### PR DESCRIPTION
I tried building the current master (5c00aa9) and had some problems. I also ran [catkin_lint](https://github.com/fkie/catkin_lint) and fixed some of the things it reported.

I realize that the build instructions suggest manually running

```
sudo apt install build-essential cmake libglfw3-dev libglew-dev libeigen3-dev \
     libjsoncpp-dev libtclap-dev
```

but it's more convenient to have all dependencies properly declared so that you can simply ask rosdep to take care of everything, regardless of platform. (With `rosdep install`.)

* GLEW and GLFW3 were not declared. This breaks the build if you use rosdep.
* Some dependencies are declared as `build_depend` and `exec_depends` but not `build_export_depend`. Changed these to simply `depend`, as that covers all three.
* Eigen dependency used wrong rosdep keyword, changed from `libeigen3` to `eigen`.
    * (Check `rosdep resolve libeigen3` vs. `rosdep resolve eigen`.)
* Added a missing exec_depend on topic_tools.