### PR TITLE
Fixed eigen dependency name

### DIFF
--- a/ouster_ros/package.xml
+++ b/ouster_ros/package.xml
@@ -8,7 +8,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>libjsoncpp</build_depend>
-  <build_depend>libeigen3</build_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>


### PR DESCRIPTION
`rosdep install` fails on libeigen3 dependency as it is indexed as `eigen` in rosdep repository: https://index.ros.org/d/eigen/