### PR TITLE
add BUILD_VIZ option to ROS cmake

### DIFF
--- a/ouster_ros/CMakeLists.txt
+++ b/ouster_ros/CMakeLists.txt
@@ -6,10 +6,14 @@ include(DefaultBuildType)
 # ==== Project Name ====
 project(ouster_ros)
 
+option(BUILD_VIZ "Build Ouster visualizer." ON)
+
 # ==== Requirements ====
 find_package(Eigen3 REQUIRED)
-find_package(GLEW REQUIRED)
-find_package(glfw3 REQUIRED)
+if(BUILD_VIZ)
+  find_package(GLEW REQUIRED)
+  find_package(glfw3 REQUIRED)
+endif()
 
 find_package(
   catkin REQUIRED
@@ -34,7 +38,13 @@ add_message_files(FILES PacketMsg.msg)
 add_service_files(FILES OSConfigSrv.srv)
 generate_messages(DEPENDENCIES std_msgs sensor_msgs geometry_msgs)
 
-set(_ouster_ros_INCLUDE_DIRS "include;../ouster_client/include;../ouster_viz/include")
+if(BUILD_VIZ)
+  set(_ouster_ros_INCLUDE_DIRS "include;../ouster_client/include;../ouster_viz/include")
+  set(_ouster_ros_DEPENDS "EIGEN3 GLFW3 GLEW")
+else()
+  set(_ouster_ros_INCLUDE_DIRS "include;../ouster_client/include")
+  set(_ouster_ros_DEPENDS "EIGEN3")
+endif()
 
 catkin_package(
   INCLUDE_DIRS
@@ -49,7 +59,7 @@ catkin_package(
     sensor_msgs
     geometry_msgs
   DEPENDS
-    EIGEN3 GLFW3 GLEW)
+    ${_ouster_ros_DEPENDS})
 
 # ==== Libraries ====
 # Build static libraries and bundle them into ouster_ros using the `--whole-archive` flag. This is
@@ -58,15 +68,22 @@ catkin_package(
 set(_SAVE_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(../ouster_client ouster_client EXCLUDE_FROM_ALL)
-add_subdirectory(../ouster_viz ouster_viz EXCLUDE_FROM_ALL)
+if(BUILD_VIZ)
+  add_subdirectory(../ouster_viz ouster_viz EXCLUDE_FROM_ALL)
+endif()
 set(BUILD_SHARED_LIBS ${_SAVE_BUILD_SHARED_LIBS})
 
 # catkin adds all include dirs to a single variable, don't try to use targets
 include_directories(${_ouster_ros_INCLUDE_DIRS} SYSTEM ${catkin_INCLUDE_DIRS})
 
 add_library(ouster_ros src/ros.cpp)
-target_link_libraries(ouster_ros PUBLIC ${catkin_LIBRARIES} ouster_build PRIVATE
-  -Wl,--whole-archive ouster_client ouster_viz -Wl,--no-whole-archive)
+if(BUILD_VIZ)
+  target_link_libraries(ouster_ros PUBLIC ${catkin_LIBRARIES} ouster_build PRIVATE
+    -Wl,--whole-archive ouster_client ouster_viz -Wl,--no-whole-archive)
+else()
+  target_link_libraries(ouster_ros PUBLIC ${catkin_LIBRARIES} ouster_build PRIVATE
+    -Wl,--whole-archive ouster_client -Wl,--no-whole-archive)
+endif()
 add_dependencies(ouster_ros ${PROJECT_NAME}_gencpp)
 
 # ==== Executables ====
@@ -78,20 +95,29 @@ add_executable(os_cloud_node src/os_cloud_node.cpp)
 target_link_libraries(os_cloud_node ouster_ros ${catkin_LIBRARIES})
 add_dependencies(os_cloud_node ${PROJECT_NAME}_gencpp)
 
-add_executable(viz_node src/viz_node.cpp)
-target_link_libraries(viz_node ouster_ros ${catkin_LIBRARIES} glfw GLEW)
-add_dependencies(viz_node ${PROJECT_NAME}_gencpp)
+if(BUILD_VIZ)
+  add_executable(viz_node src/viz_node.cpp)
+  target_link_libraries(viz_node ouster_ros ${catkin_LIBRARIES} glfw GLEW)
+  add_dependencies(viz_node ${PROJECT_NAME}_gencpp)
 
-add_executable(img_node src/img_node.cpp)
-target_link_libraries(img_node ouster_ros ${catkin_LIBRARIES})
-add_dependencies(img_node ${PROJECT_NAME}_gencpp)
+  add_executable(img_node src/img_node.cpp)
+  target_link_libraries(img_node ouster_ros ${catkin_LIBRARIES})
+  add_dependencies(img_node ${PROJECT_NAME}_gencpp)
+endif()
 
 # ==== Install ====
 install(
-  TARGETS ouster_ros os_node os_cloud_node viz_node img_node
+  TARGETS ouster_ros os_node os_cloud_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+if(BUILD_VIZ)
+  install(
+    TARGETS viz_node img_node
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+endif()
 install(
   DIRECTORY ${_ouster_ros_INCLUDE_DIRS}
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})


### PR DESCRIPTION
add `BUILD_VIZ` support to ROS cmake, defaulting to `ON`. This allows viz disable w/:

```shell
$ catkin_make -DBUILD_VIZ=OFF
```
