### PR TITLE
allow changing ROS tf frame names via params

### DIFF
--- a/ouster_ros/ouster.launch
+++ b/ouster_ros/ouster.launch
@@ -11,6 +11,9 @@
   <arg name="viz" default="false" doc="whether to run a simple visualizer"/>
   <arg name="image" default="false" doc="publish range/intensity/ambient image topic"/>
   <arg name="tf_prefix" default="" doc="namespace for tf transforms"/>
+  <arg name="sensor_frame" default="os_sensor" doc="sensor tf frame"/>
+  <arg name="imu_frame" default="os_imu" doc="imu tf frame"/>
+  <arg name="lidar_frame" default="os_lidar" doc="lidar tf frame"/>
 
   <node pkg="ouster_ros" name="os_node" type="os_node" output="screen" required="true">
     <param name="~/lidar_mode" type="string" value="$(arg lidar_mode)"/>

--- a/ouster_ros/src/os_cloud_node.cpp
+++ b/ouster_ros/src/os_cloud_node.cpp
@@ -31,9 +31,9 @@ int main(int argc, char** argv) {
 
     auto tf_prefix = nh.param("tf_prefix", std::string{});
     if (!tf_prefix.empty() && tf_prefix.back() != '/') tf_prefix.append("/");
-    auto sensor_frame = tf_prefix + "os_sensor";
-    auto imu_frame = tf_prefix + "os_imu";
-    auto lidar_frame = tf_prefix + "os_lidar";
+    auto sensor_frame = tf_prefix + nh.param("sensor_frame", std::string("os_sensor"));
+    auto imu_frame = tf_prefix + nh.param("imu_frame", std::string("os_imu"));
+    auto lidar_frame = tf_prefix + nh.param("lidar_frame", std::string("os_lidar"));
 
     ouster_ros::OSConfigSrv cfg{};
     auto client = nh.serviceClient<ouster_ros::OSConfigSrv>("os_config");


### PR DESCRIPTION
allow changing ROS tf frame names via params:

* `sensor_frame`
* `imu_frame`
* ` lidar_frame`

keeping current values are defaults and expose as ROS launch args.