### PR TITLE
build-fixes

### DIFF
--- a/ouster_client/include/ouster/types.h
+++ b/ouster_client/include/ouster/types.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <json/json.h>
-
 #include <Eigen/Eigen>
 #include <set>
 #include <string>

--- a/ouster_client/src/example.cpp
+++ b/ouster_client/src/example.cpp
@@ -118,7 +118,7 @@ int main(int argc, char* argv[]) {
                     });
                 // retry until we receive a full set of valid measurements
                 // (accounting for azimuth_window settings if any)
-                if (n_invalid <= w - column_window_length) i++;
+                if (n_invalid <= (int)w - column_window_length) i++;
             }
         }
 


### PR DESCRIPTION
Fix errors preventing users from building `ouster_ros `and `ouster_client`

* remove unnecessary json.h include
* fix example.cpp type error