### PR TITLE
Support set_udp_dest_auto in client init

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ and write point clouds out to CSV files::
     ./ouster_client_example <sensor hostname> <udp data destination>
 
 where ``<sensor hostname>`` can be the hostname (os-99xxxxxxxxxx) or IP of the sensor and ``<udp
-data destingation>`` is the hostname or IP to which the sensor should send lidar data.
+data destingation>`` is the hostname or IP to which the sensor should send lidar data. You can also supply ``""``, an empty string, to utilize automatic detection.
 
 On Windows, you may need to allow the client/visualizer through the Windows firewall to receive
 sensor data.
@@ -236,7 +236,7 @@ another terminal, run::
 
     rosbag record /os_node/imu_packets /os_node/lidar_packets
 
-This will save a bag file of recorded data in the current working directory. 
+This will save a bag file of recorded data in the current working directory.
 
 It's recommended to
 copy and save the metadata file at ``$(ROS_HOME)/<sensor_hostname>.json`` alongside the bag.

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -43,6 +43,7 @@ std::shared_ptr<client> init_client(const std::string& hostname = "",
  *
  * @param hostname hostname or ip of the sensor
  * @param udp_dest_host hostname or ip where the sensor should send data
+ * or "" for automatic detection of destination
  * @param lidar_port port on which the sensor will send lidar data
  * @param imu_port port on which the sensor will send imu data
  * @param timeout_sec how long to wait for the sensor to initialize

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -328,9 +328,19 @@ std::shared_ptr<client> init_client(const std::string& hostname,
     std::string res;
     bool success = true;
 
+  // If udp_dest_host is empty string, use automatic addressing with set_udp_dest_auto
+  if (udp_dest_host != "")
+  {
     success &=
-        do_tcp_cmd(sock_fd, {"set_config_param", "udp_ip", udp_dest_host}, res);
+      do_tcp_cmd(sock_fd, {"set_config_param", "udp_ip", udp_dest_host}, res);
     success &= res == "set_config_param";
+  }
+  else
+  {
+    success &=
+      do_tcp_cmd(sock_fd, {"set_udp_dest_auto"}, res);
+      success &= res == "set_udp_dest_auto";
+  }
 
     success &= do_tcp_cmd(
         sock_fd,


### PR DESCRIPTION
I don't like keeping track of my computer's IP address in applications. The ouster's API already supports automatic detection of the udp destination with `set_udp_dest_auto` based on the originator of the TCP command. I added support for it in this PR.
@SteveMacenski This is a bit different than in ROS2 because I updated the comment in the header file. These changes should be used instead.

Signed-off-by: Ryan Friedman <ryan_friedman@trimble.com>