### PR TITLE
Add timeout flag to config socket

### DIFF
--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -46,6 +46,8 @@ std::shared_ptr<client> init_client(const std::string& hostname = "",
  * @param lidar_port port on which the sensor will send lidar data
  * @param imu_port port on which the sensor will send imu data
  * @param timeout_sec how long to wait for the sensor to initialize
+ * @param cfg_timeout_ms how long to wait for config response
+ * Set to 0 to block until response
  * @return pointer owning the resources associated with the connection
  */
 std::shared_ptr<client> init_client(const std::string& hostname,
@@ -53,7 +55,8 @@ std::shared_ptr<client> init_client(const std::string& hostname,
                                     lidar_mode mode = MODE_UNSPEC,
                                     timestamp_mode ts_mode = TIME_FROM_UNSPEC,
                                     int lidar_port = 0, int imu_port = 0,
-                                    int timeout_sec = 30);
+                                    int timeout_sec = 30,
+                                    int cfg_timeout_ms = 0);
 
 /**
  * Block for up to timeout_sec until either data is ready or an error occurs.
@@ -96,9 +99,12 @@ bool read_imu_packet(const client& cli, uint8_t* buf, const packet_format& pf);
  *
  * @param cli client returned by init_client associated with the connection
  * @param timeout_sec how long to wait for the sensor to initialize
+ * @param cfg_timeout_ms how long to wait for config response
+ * Set to 0 to block until response
  * @return a text blob of metadata parseable into a sensor_info struct
  */
-std::string get_metadata(client& cli, int timeout_sec = 30);
+std::string get_metadata(client& cli, int timeout_sec = 30,
+                         int cfg_timeout_ms = 0);
 
 /**
  * Get sensor config from the sensor
@@ -108,10 +114,12 @@ std::string get_metadata(client& cli, int timeout_sec = 30);
  * @param hostname sensor hostname
  * @param config sensor config to populate
  * @param active whether to pull active or passive configs
+ * @param cfg_timeout_ms how long to wait for config response
+ * Set to 0 to block until response
  * @return true if sensor config successfully populated
  */
 bool get_config(const std::string& hostname, sensor_config& config,
-                bool active = true);
+                bool active = true, int cfg_timeout_ms = 0);
 
 /**
  * Set sensor config on sensor
@@ -119,9 +127,11 @@ bool get_config(const std::string& hostname, sensor_config& config,
  * @param hostname sensor hostname
  * @param sensor config
  * @param flags flags to pass in
+ * @param cfg_timeout_ms how long to wait for config response
+ * Set to 0 to block until response
  * @return true if config params successfuly set on sensor
  */
 bool set_config(const std::string& hostname, const sensor_config& config,
-                uint8_t config_flags = 0);
+                uint8_t config_flags = 0, int cfg_timeout_ms = 0);
 }  // namespace sensor
 }  // namespace ouster

--- a/ouster_client/include/ouster/impl/netcompat.h
+++ b/ouster_client/include/ouster/impl/netcompat.h
@@ -38,6 +38,7 @@
 #endif
 
 #define SOCKET_ERROR -1
+#define SOCKET_SUCCESS 0
 
 #endif  // --------- End Platform Differentiation Block ---------
 
@@ -62,7 +63,7 @@ std::string socket_get_error();
  * @param sock The socket file descriptor to check
  * @return The validity of the socket file descriptor
  */
-bool socket_valid(SOCKET value);
+bool socket_valid(SOCKET sock);
 
 /**
  * Check if the last error was a socket exit event
@@ -75,14 +76,23 @@ bool socket_exit();
  * @param sock The socket file descriptor to set non-blocking
  * @return success
  */
-int socket_set_non_blocking(SOCKET value);
+int socket_set_non_blocking(SOCKET sock);
 
 /**
  * Set a specified socket to reuse
  * @param sock The socket file descriptor to set reuse
  * @return success
  */
-int socket_set_reuse(SOCKET value);
+int socket_set_reuse(SOCKET sock);
+
+/**
+ * Set a specified socket's receive timeout
+ * @param sock The socket file descriptor to add timeout
+ * @param timeout_ms The timeout, in milliseconds
+ * A timeout of zero will be ignored
+ * @return success
+ */
+int socket_set_rcvtimeout(SOCKET sock, int timeout_ms);
 
 }  // namespace impl
 }  // namespace ouster

--- a/ouster_client/src/netcompat.cpp
+++ b/ouster_client/src/netcompat.cpp
@@ -73,22 +73,34 @@ bool socket_exit() {
 #endif
 }
 
-int socket_set_non_blocking(SOCKET value) {
+int socket_set_non_blocking(SOCKET sock) {
 #ifdef _WIN32
     u_long non_blocking_mode = 0;
-    return ioctlsocket(value, FIONBIO, &non_blocking_mode);
+    return ioctlsocket(sock, FIONBIO, &non_blocking_mode);
 #else
-    return fcntl(value, F_SETFL, fcntl(value, F_GETFL, 0) | O_NONBLOCK);
+    return fcntl(sock, F_SETFL, fcntl(sock, F_GETFL, 0) | O_NONBLOCK);
 #endif
 }
 
-int socket_set_reuse(SOCKET value) {
+int socket_set_reuse(SOCKET sock) {
 #ifdef _WIN32
     u_long reuse = 1;
-    return ioctlsocket(value, SO_REUSEADDR, &reuse);
+    return ioctlsocket(sock, SO_REUSEADDR, &reuse);
 #else
     int option = 1;
-    return setsockopt(value, SOL_SOCKET, SO_REUSEADDR, &option, sizeof(option));
+    return setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &option, sizeof(option));
+#endif
+}
+
+int socket_set_rcvtimeout(SOCKET sock, int timeout_ms) {
+#ifdef _WIN32
+    DWORD timeout = timeout_ms;
+    return setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout, sizeof timeout);
+#else
+    struct timeval tv;
+    tv.tv_sec = timeout_ms / 1000;
+    tv.tv_usec = 1000*(timeout_ms % 1000) ;
+    return setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof tv);
 #endif
 }
 


### PR DESCRIPTION
* Added optional config socket timeout to client that defaults to zero
* The same functionality is retained (block until
data arrives), keeping API the same
* Add optional timeout to bail out of the
config phase, specified in milliseconds
* Improve debugging message consistency across functions
* Improve consistency in parameter arguments and doxygen comments
* Proposed implementation to fix issue #257

Signed-off-by: Ryan Friedman <ryan_friedman@trimble.com>