### PR TITLE
Change From Metadata Service To Topic

### DIFF
--- a/ouster_ros/CMakeLists.txt
+++ b/ouster_ros/CMakeLists.txt
@@ -28,7 +28,7 @@ add_compile_options(-Wall -Wextra -Werror)
 option(CMAKE_POSITION_INDEPENDENT_CODE "Build position independent code." ON)
 
 # ==== Catkin ====
-add_message_files(FILES PacketMsg.msg)
+add_message_files(FILES PacketMsg.msg SensorMetadata.msg)
 add_service_files(FILES OSConfigSrv.srv)
 generate_messages(DEPENDENCIES std_msgs sensor_msgs geometry_msgs)
 

--- a/ouster_ros/CMakeLists.txt
+++ b/ouster_ros/CMakeLists.txt
@@ -29,7 +29,6 @@ option(CMAKE_POSITION_INDEPENDENT_CODE "Build position independent code." ON)
 
 # ==== Catkin ====
 add_message_files(FILES PacketMsg.msg SensorMetadata.msg)
-add_service_files(FILES OSConfigSrv.srv)
 generate_messages(DEPENDENCIES std_msgs sensor_msgs geometry_msgs)
 
 set(_ouster_ros_INCLUDE_DIRS

--- a/ouster_ros/include/ouster_ros/ros.h
+++ b/ouster_ros/include/ouster_ros/ros.h
@@ -6,10 +6,14 @@
 
 #pragma once
 
+#include <ros/ros.h>
+
 #include <geometry_msgs/TransformStamped.h>
 #include <pcl/point_cloud.h>
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/PointCloud2.h>
+
+#include <ouster_ros/SensorMetadata.h>
 
 #include <chrono>
 #include <string>
@@ -25,6 +29,8 @@ namespace ouster_ros {
 namespace sensor = ouster::sensor;
 using Cloud = pcl::PointCloud<Point>;
 using ns = std::chrono::nanoseconds;
+
+std::string get_sensor_metadata_ros(ros::NodeHandle& nh);
 
 /**
  * Read an imu packet into a ROS message. Blocks for up to a second if no data
@@ -87,4 +93,6 @@ sensor_msgs::PointCloud2 cloud_to_cloud_msg(const Cloud& cloud, ns timestamp,
 geometry_msgs::TransformStamped transform_to_tf_msg(
     const ouster::mat4d& mat, const std::string& frame,
     const std::string& child_frame);
+
+
 }  // namespace ouster_ros

--- a/ouster_ros/msg/SensorMetadata.msg
+++ b/ouster_ros/msg/SensorMetadata.msg
@@ -1,0 +1,2 @@
+# This message contains the sensor metadata document that ouster needs for bag playback
+string data

--- a/ouster_ros/src/img_node.cpp
+++ b/ouster_ros/src/img_node.cpp
@@ -26,7 +26,6 @@
 #include "ouster/client.h"
 #include "ouster/image_processing.h"
 #include "ouster/types.h"
-#include "ouster_ros/OSConfigSrv.h"
 #include "ouster_ros/ros.h"
 
 namespace sensor = ouster::sensor;
@@ -51,16 +50,15 @@ sensor_msgs::ImagePtr make_image_msg(size_t H, size_t W,
 int main(int argc, char** argv) {
     ros::init(argc, argv, "img_node");
     ros::NodeHandle nh("~");
-
-    ouster_ros::OSConfigSrv cfg{};
-    auto client = nh.serviceClient<ouster_ros::OSConfigSrv>("os_config");
-    client.waitForExistence();
-    if (!client.call(cfg)) {
-        ROS_ERROR("Calling os config service failed");
-        return EXIT_FAILURE;
+    
+    auto metadata = ouster_ros::get_sensor_metadata_ros(nh);
+    if (!metadata.length())
+    {
+      ROS_ERROR("Getting metadata failed.");
+      return EXIT_FAILURE;
     }
 
-    auto info = sensor::parse_metadata(cfg.response.metadata);
+    auto info = sensor::parse_metadata(metadata);
     size_t H = info.format.pixels_per_column;
     size_t W = info.format.columns_per_frame;
 

--- a/ouster_ros/src/os_cloud_node.cpp
+++ b/ouster_ros/src/os_cloud_node.cpp
@@ -16,7 +16,6 @@
 
 #include "ouster/lidar_scan.h"
 #include "ouster/types.h"
-#include "ouster_ros/OSConfigSrv.h"
 #include "ouster_ros/PacketMsg.h"
 #include "ouster_ros/ros.h"
 
@@ -35,15 +34,14 @@ int main(int argc, char** argv) {
     auto imu_frame = tf_prefix + "os_imu";
     auto lidar_frame = tf_prefix + "os_lidar";
 
-    ouster_ros::OSConfigSrv cfg{};
-    auto client = nh.serviceClient<ouster_ros::OSConfigSrv>("os_config");
-    client.waitForExistence();
-    if (!client.call(cfg)) {
-        ROS_ERROR("Calling config service failed");
-        return EXIT_FAILURE;
+    auto metadata = ouster_ros::get_sensor_metadata_ros(nh);
+    if (!metadata.length())
+    {
+      ROS_ERROR("Getting metadata failed.");
+      return EXIT_FAILURE;
     }
 
-    auto info = sensor::parse_metadata(cfg.response.metadata);
+    auto info = sensor::parse_metadata(metadata);
     uint32_t H = info.format.pixels_per_column;
     uint32_t W = info.format.columns_per_frame;
 

--- a/ouster_ros/src/ros.cpp
+++ b/ouster_ros/src/ros.cpp
@@ -16,6 +16,27 @@ namespace ouster_ros {
 
 namespace sensor = ouster::sensor;
 
+std::string get_sensor_metadata_ros(ros::NodeHandle& nh)
+{
+    bool metadata_found = false;
+    std::string metadata;
+    ros::Subscriber meta_sub = nh.subscribe<ouster_ros::SensorMetadata, const ouster_ros::SensorMetadataConstPtr&>("metadata", 1, 
+                  [&](const ouster_ros::SensorMetadataConstPtr& msg)
+    {
+        metadata = msg->data;
+        metadata_found = true;
+        ROS_INFO("Got sensor metadata");
+    });
+    while (!metadata_found && ros::ok())
+    {
+        // wait for metadata
+        ROS_WARN_THROTTLE(5.0, "Waiting for sensor metadata.");
+        ros::WallDuration(0.1).sleep();
+        ros::spinOnce();
+    }
+    return metadata;
+}
+
 bool read_imu_packet(const sensor::client& cli, PacketMsg& m,
                      const sensor::packet_format& pf) {
     m.buf.resize(pf.imu_packet_size + 1);

--- a/ouster_ros/srv/OSConfigSrv.srv
+++ b/ouster_ros/srv/OSConfigSrv.srv
@@ -1,2 +1,0 @@
----
-string metadata


### PR DESCRIPTION
Having an external metadata file complicates things like doing bag file playback. We believe storing this data in a message based approach is both more maintainable and "ROSlike". It also enables storing the metadata in the bag file itself.

This pull request adds the ability to use a topic to obtain sensor metadata both for playback and on a live system if you leave the metadata parameter blank. It replaces all usages of the config service with this topic as well.