### PR TITLE
Move the constexpr N_FIELDS outside of the LidarScan class

### DIFF
--- a/ouster_client/include/ouster/lidar_scan.h
+++ b/ouster_client/include/ouster/lidar_scan.h
@@ -15,6 +15,8 @@
 
 namespace ouster {
 
+static constexpr int N_LIDAR_SCAN_FIELDS = 4;
+
 /**
  * Datastructure for efficient operations on aggregated lidar data.
  *
@@ -28,11 +30,9 @@ namespace ouster {
  */
 class LidarScan {
    public:
-    static constexpr int N_FIELDS = 4;
-
     using raw_t = uint32_t;
     using ts_t = std::chrono::nanoseconds;
-    using data_t = Eigen::Array<raw_t, Eigen::Dynamic, N_FIELDS>;
+    using data_t = Eigen::Array<raw_t, Eigen::Dynamic, N_LIDAR_SCAN_FIELDS>;
 
     using DynStride = Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>;
 
@@ -68,7 +68,7 @@ class LidarScan {
     LidarScan(size_t w, size_t h)
         : w{static_cast<std::ptrdiff_t>(w)},
           h{static_cast<std::ptrdiff_t>(h)},
-          data{w * h, N_FIELDS},
+          data{w * h, N_LIDAR_SCAN_FIELDS},
           headers{w, BlockHeader{ts_t{0}, 0, 0}} {};
 
     /**
@@ -101,14 +101,14 @@ class LidarScan {
      */
     Eigen::Map<data_t, Eigen::Unaligned, DynStride> block(size_t m_id) {
         return Eigen::Map<data_t, Eigen::Unaligned, DynStride>(
-            data.row(m_id).data(), h, N_FIELDS, {w * h, w});
+            data.row(m_id).data(), h, N_LIDAR_SCAN_FIELDS, {w * h, w});
     }
 
     /** @copydoc block(size_t m_id) */
     Eigen::Map<const data_t, Eigen::Unaligned, DynStride> block(
         size_t m_id) const {
         return Eigen::Map<const data_t, Eigen::Unaligned, DynStride>(
-            data.row(m_id).data(), h, N_FIELDS, {w * h, w});
+            data.row(m_id).data(), h, N_LIDAR_SCAN_FIELDS, {w * h, w});
     }
 
     /**

--- a/ouster_client/src/lidar_scan.cpp
+++ b/ouster_client/src/lidar_scan.cpp
@@ -6,8 +6,6 @@
 
 namespace ouster {
 
-constexpr int LidarScan::N_FIELDS;
-
 XYZLut make_xyz_lut(size_t w, size_t h, double range_unit,
                     double lidar_origin_to_beam_origin_mm,
                     const mat4d& transform,
@@ -102,7 +100,7 @@ bool ScanBatcher::operator()(const uint8_t* packet_buf, LidarScan& ls) {
             // if not initializing with first packet
             if (ls_write.frame_id != -1) {
                 // zero out remaining missing columns
-                auto rows = h * LidarScan::N_FIELDS;
+                auto rows = h * N_LIDAR_SCAN_FIELDS;
                 row_view_t{ls_write.data.data(), rows, w}
                     .block(0, next_m_id, rows, w - next_m_id)
                     .setZero();
@@ -119,7 +117,7 @@ bool ScanBatcher::operator()(const uint8_t* packet_buf, LidarScan& ls) {
 
         // zero out missing columns if we jumped forward
         if (m_id >= next_m_id) {
-            auto rows = h * LidarScan::N_FIELDS;
+            auto rows = h * N_LIDAR_SCAN_FIELDS;
             row_view_t{ls_write.data.data(), rows, w}
                 .block(0, next_m_id, rows, m_id - next_m_id)
                 .setZero();


### PR DESCRIPTION
There is an issue with static constexpr members with projects mixing c++ versions >= 17 and those less than that. Specifically, C++17 implicitly inlines static constexpr variables, whereas C++14 and below require an instance. 

In your codebase, you seem to be implictly using C++14 and below. Thus you define the LidarScan::N_FIELDS variable in the header (`lidar_scan.h`):

```
class LidarScan {
   public:
    static constexpr int N_FIELDS = 4;
```

and also declare it in the translation unit (`lidar_scan.cpp`): 

`constexpr int LidarScan::N_FIELDS;`

The issue arises when you try to compile you try to use your `ouster_client` libraries in executables that are building with anything >=C++17. The issue arises because C++17 will see the header, and implicitly inline the N_FIELDS variable. This will lead to a compile time error because the variable has already been defined in `lidar_scan.cpp`. The easiest way to see this is to try to compile your ouster_client_example with C++17: (add these lines to line 49 of your `ouster_client/CMakeLists.txt` file):
```
set_target_properties(ouster_client_example
        PROPERTIES
        CXX_STANDARD 17
        CXX_EXTENSIONS off
        )
```

So how can we resolve this?

Some options I can think of are to 
1. Force everybody to use >= C++17 (which doesn't seem like a great option). In this case, you could remove the declaration in lidar_scan.cpp.
2. You could change N_FIELDS to an integral_constant:  `using N_FIELDS = std::integral_constant<int, 4>;`, and then remove the declaration from `lidar_scan.cpp` and update the usages to read `N_FIELDS::value`. This gives you a compile time value that is still part of the LidarScan class. 
3. Use this pull request, which moves the constexpr outside of the class to the namespace. This will work regardless of the standard version. 

One option that is typically used in cases like this is to change the member to a constexpr function. Specifically, to remove the declaration in lidar_scan.cpp, and to change the definition to 
```
static constexpr int N_FIELDS(){
    return 4;
}
```
But I do not think that that will work here because you need the value in other compile-time expressions in the LidarScan class, and the class needs to be "complete" before you can use that function. 

Anyways, here is a Stackoverflow comment with some more details about the static constexpr member problem:

https://stackoverflow.com/a/28846608/3309610
