### PR TITLE
Fixed pedantic compiler warning which is dealt as error with actual compiler options

### DIFF
--- a/ouster_client/src/types.cpp
+++ b/ouster_client/src/types.cpp
@@ -837,7 +837,7 @@ version version_of_string(const std::string& s) {
         return v;
     else
         return invalid_version;
-};
+}
 
 }  // namespace util
 


### PR DESCRIPTION
Fixed -Wpedantic warning which is dealt as error due to actual compiler options.