### PR TITLE
Do not include unnecessary Eigen headers

### DIFF
--- a/ouster_client/include/ouster/types.h
+++ b/ouster_client/include/ouster/types.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <Eigen/Dense>
+#include <Eigen/Core>
 #include <array>
 #include <cstdint>
 #include <map>


### PR DESCRIPTION
Minimally reduces compilation time as Eigen is very expensive to parse.