### PR TITLE
ROS service to change lidar config

### DIFF
--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -137,5 +137,20 @@ enum config_flags : uint8_t {
  */
 bool set_config(const std::string& hostname, const sensor_config& config,
                 uint8_t config_flags = 0);
+
+/**
+ * Set sensor config on sensor using string inputs
+ *
+ * @throw runtime_error on failure to communcate with the sensor
+ * @throw invalid_argument when config parameters fail validation
+ * @param hostname sensor hostname
+ * @param key the parameter key to change
+ * @param value the value/input of the parameter
+ * @param flags flags to pass in
+ * @return true if config params successfuly set on sensor
+ */
+bool set_config_from_string(const std::string& hostname, const std::string key,
+                const std::string value, uint8_t config_flags = 0);
+
 }  // namespace sensor
 }  // namespace ouster

--- a/ouster_ros/CMakeLists.txt
+++ b/ouster_ros/CMakeLists.txt
@@ -29,7 +29,7 @@ option(CMAKE_POSITION_INDEPENDENT_CODE "Build position independent code." ON)
 
 # ==== Catkin ====
 add_message_files(FILES PacketMsg.msg)
-add_service_files(FILES OSConfigSrv.srv)
+add_service_files(FILES OSConfigSrv.srv LidarConfigSrv.srv)
 generate_messages(DEPENDENCIES std_msgs sensor_msgs geometry_msgs)
 
 set(_ouster_ros_INCLUDE_DIRS

--- a/ouster_ros/src/os_node.cpp
+++ b/ouster_ros/src/os_node.cpp
@@ -141,7 +141,7 @@ int main(int argc, char** argv) {
             ROS_INFO("received lidar config request: R1=%s, R2=%s", req.key.c_str(), req.value.c_str());
             bool result = sensor::set_config_from_string(hostname, req.key, req.value, req.config_flag);
             if(result){
-                ROS_INFO("Lidar reinitializing with new config");
+                ROS_INFO("config success. Lidar reinitializing with new config");
                 res.success = true;
                 return true;
             }

--- a/ouster_ros/srv/LidarConfigSrv.srv
+++ b/ouster_ros/srv/LidarConfigSrv.srv
@@ -1,0 +1,5 @@
+string key
+string value
+uint8 config_flag
+---
+bool success


### PR DESCRIPTION
`/os_node/lidar_config` service is now available to change configuration params on the lidar via a ROS service. Takes in three input parameters: key, value and config_flag. Additional function `set_config_from_string()` added in client.cpp to set config params from string input. 

For example, to set lidar to standby send `key: "operating_mode", value: "STANDBY", config_flag: "0"`