### PR TITLE
Update Point.h to reduce memory footprint

### DIFF
--- a/ouster_ros/include/ouster_ros/point.h
+++ b/ouster_ros/include/ouster_ros/point.h
@@ -18,11 +18,11 @@ namespace ouster_ros {
 struct EIGEN_ALIGN16 Point {
     PCL_ADD_POINT4D;
     float intensity;
+    uint32_t range;
     uint32_t t;
     uint16_t reflectivity;
-    uint8_t ring;
     uint16_t ambient;
-    uint32_t range;
+    uint8_t ring;
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 }  // namespace ouster_ros
@@ -34,10 +34,10 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::Point,
     (float, z, z)
     (float, intensity, intensity)
     // use std::uint32_t to avoid conflicting with pcl::uint32_t
+    (std::uint32_t, range, range)
     (std::uint32_t, t, t)
     (std::uint16_t, reflectivity, reflectivity)
-    (std::uint8_t, ring, ring)
     (std::uint16_t, ambient, ambient)
-    (std::uint32_t, range, range)
+    (std::uint8_t, ring, ring)
 )
 // clang-format on


### PR DESCRIPTION
Old footprint: 48 bytes
New footprint: 32 byts

Reduces memory bandwidth with ROS by 33% 🥈 

For optimal reduction to 29 bytes, please see issue in PCL: https://github.com/PointCloudLibrary/pcl/issues/4939

Followup on issue faced by @peci1