### PR TITLE
Ring type change

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+[Unreleased]
+============
+
+ouster_ros
+----------
+* Updated PCL ring type from Uint8 to Uint16
 
 [20220107]
 ============

--- a/ouster_ros/include/ouster_ros/point.h
+++ b/ouster_ros/include/ouster_ros/point.h
@@ -20,7 +20,7 @@ struct EIGEN_ALIGN16 Point {
     float intensity;
     uint32_t t;
     uint16_t reflectivity;
-    uint8_t ring;
+    uint16_t ring;
     uint16_t ambient;
     uint32_t range;
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -36,7 +36,7 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::Point,
     // use std::uint32_t to avoid conflicting with pcl::uint32_t
     (std::uint32_t, t, t)
     (std::uint16_t, reflectivity, reflectivity)
-    (std::uint8_t, ring, ring)
+    (std::uint16_t, ring, ring)
     (std::uint16_t, ambient, ambient)
     (std::uint32_t, range, range)
 )

--- a/ouster_ros/include/ouster_ros/point.h
+++ b/ouster_ros/include/ouster_ros/point.h
@@ -20,7 +20,7 @@ struct EIGEN_ALIGN16 Point {
     float intensity;
     uint32_t t;
     uint16_t reflectivity;
-    uint16_t ring;
+    std::uint16_t ring;
     uint16_t ambient;
     uint32_t range;
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW


### PR DESCRIPTION
This pull request updates the current PCL ring type from Uint8_t  to Uint16_t. The PR addresses issue ouster-lidar/ouster-ros#14.

