### PR TITLE
Declare catkin_INCLUDE_DIRS as SYSTEM to avoid compile checks

### DIFF
--- a/ouster_ros/CMakeLists.txt
+++ b/ouster_ros/CMakeLists.txt
@@ -62,7 +62,7 @@ target_compile_definitions(ouster_client PUBLIC EIGEN_MAX_ALIGN_BYTES=32)
 set(BUILD_SHARED_LIBS ${_SAVE_BUILD_SHARED_LIBS})
 
 # catkin adds all include dirs to a single variable, don't try to use targets
-include_directories(${_ouster_ros_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+include_directories(${_ouster_ros_INCLUDE_DIRS} SYSTEM ${catkin_INCLUDE_DIRS})
 
 # use only MPL-licensed parts of eigen
 add_definitions(-DEIGEN_MPL2_ONLY)


### PR DESCRIPTION
Fixes build failing because of header of used libraries not passing compiler checks

E. g. using gcc-9 leads to `/opt/ros/melodic/include/tf2_eigen/tf2_eigen.h` throwing a deprecation warning, which leads to the compilation of this project to fail.