### PR TITLE
Update changelog for new ros timestamp mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ ouster_ros
 * drop FW 1.13 compatibility for sensors and recorded bags
 * remove setting of EIGEN_MAX_ALIGN_BYTES
 * add two new ros services /ouster/get_config and /ouster/set_config (experimental)
+* Add new timestamp_mode TIME_FROM_ROS_TIME
 
 
 [20220608]


### PR DESCRIPTION
Update changelog to reflect new ROS timestamp mode TIME_FROM_ROS_TIME