### PR TITLE
Cartesian Method Optimization (Part 1)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ ouster_client
 * added a new method ``init_logger()`` to provide control over the logs emitted by ``ouster_client``.
 * add parsing for new FW 3.0 thermal features shot_limiting and thermal_shutdown statuses and countdowns
 * add frame_status to LidarScan
+* introduce a new method ``cartesianT()`` which speeds up the computation of point projecion from range
+  image, the method also can process the cartesian product with single float precision. A new unit test
+  ``cartesian_test`` which shows achieved speed up gains by the number of valid returns in lidar scan.
 
 python
 ------

--- a/ouster_client/include/ouster/impl/cartesian.h
+++ b/ouster_client/include/ouster/impl/cartesian.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <ouster/lidar_scan.h>
+
+namespace ouster {
+
+// Users can enable OpenMP within ouster_client by first enabling omp through
+// the compiler and then adding '-DOUSTER_OMP' option to the DCMAKE_CXX_FLAGS
+#if defined(OUSTER_OMP)
+    #if defined(_OPENMP)
+        #define __OUSTER_UTILIZE_OPENMP__
+    #else
+        #pragma message("OUSTER_OMP was defined but openmp is not detected!")
+    #endif
+#endif
+
+template <typename T>
+using PointsT = Eigen::Array<T, -1, 3>;
+using PointsD = PointsT<double>;
+using PointsF = PointsT<float>;
+
+/**
+ * Converts a staggered range image to Cartesian points.
+ *
+ * @param[in, out] points The resulting point cloud, should be pre-allocated and
+ * have the same dimensions as the direction array.
+ * @param[in] range a range image in the same format as the RANGE field of a
+ * LidarScan.
+ * @param[in] direction the direction of an xyz lut.
+ * @param[in] offset the offset of an xyz lut.
+ *
+ * @return Cartesian points where ith row is a 3D point which corresponds
+ *         to ith pixel in LidarScan where i = row * w + col.
+ */
+template <typename T>
+void cartesianT(PointsT<T>& points,
+                const Eigen::Ref<const img_t<uint32_t>>& range,
+                const PointsT<T>& direction, const PointsT<T>& offset) {
+    assert(points.rows() == direction.rows() &&
+           "points & direction row count mismatch");
+    assert(points.rows() == offset.rows() &&
+           "points & offset row count mismatch");
+    assert(points.rows() == range.size() &&
+           "points and range image size mismatch");
+
+    const auto        pts = points.data();
+    const auto* const rng = range.data();
+    const auto* const dir = direction.data();
+    const auto* const ofs = offset.data();
+
+    const auto N = range.size();
+    const auto col_x = 0 * N;    // 1st column of points (x)
+    const auto col_y = 1 * N;    // 2nd column of points (y)
+    const auto col_z = 2 * N;    // 3rd column of points (z)
+
+#ifdef __OUSTER_UTILIZE_OPENMP__
+#pragma omp parallel for schedule(static)
+#endif
+    for (auto i = 0; i < N; ++i) {
+        const auto r = rng[i];
+        const auto idx_x = col_x + i;
+        const auto idx_y = col_y + i;
+        const auto idx_z = col_z + i;
+        if (r == 0) {
+            pts[idx_x] = pts[idx_y] = pts[idx_z] = static_cast<T>(0.0);
+        } else {
+            pts[idx_x] = r * dir[idx_x] + ofs[idx_x];
+            pts[idx_y] = r * dir[idx_y] + ofs[idx_y];
+            pts[idx_z] = r * dir[idx_z] + ofs[idx_z];
+        }
+    }
+}
+
+}  // namespace ouster

--- a/ouster_client/include/ouster/lidar_scan.h
+++ b/ouster_client/include/ouster/lidar_scan.h
@@ -555,4 +555,5 @@ class ScanBatcher {
 
 }  // namespace ouster
 
+#include "ouster/impl/cartesian.h"
 #include "ouster/impl/lidar_scan_impl.h"

--- a/ouster_client/src/lidar_scan.cpp
+++ b/ouster_client/src/lidar_scan.cpp
@@ -384,7 +384,6 @@ LidarScan::Points cartesian(const Eigen::Ref<const img_t<uint32_t>>& range,
                             const XYZLut& lut) {
     if (range.cols() * range.rows() != lut.direction.rows())
         throw std::invalid_argument("unexpected image dimensions");
-
     auto reshaped = Eigen::Map<const Eigen::Array<uint32_t, -1, 1>>(
         range.data(), range.cols() * range.rows());
     auto nooffset = lut.direction.colwise() * reshaped.cast<double>();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,3 +32,15 @@ set_tests_properties(
         ENVIRONMENT 
         DATA_DIR=${CMAKE_CURRENT_LIST_DIR}/metadata/
 )
+
+add_executable(cartesian_test cartesian_test.cpp)
+
+target_link_libraries(cartesian_test OusterSDK::ouster_client GTest::gtest GTest::gtest_main)
+
+add_test(NAME cartesian_test COMMAND cartesian_test --gtest_output=xml:cartesian_test.xml)
+set_tests_properties(
+  cartesian_test
+        PROPERTIES 
+        ENVIRONMENT 
+        DATA_DIR=${CMAKE_CURRENT_LIST_DIR}/metadata/
+)

--- a/tests/cartesian_test.cpp
+++ b/tests/cartesian_test.cpp
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2021, Ouster, Inc.
+ * All rights reserved.
+ */
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Eigen>
+#include <chrono>
+#include <numeric>
+#include <random>
+
+#include "ouster/lidar_scan.h"
+
+class Timer {
+   public:
+    void start() { t_start = std::chrono::system_clock::now(); }
+
+    void stop() { t_end = std::chrono::system_clock::now(); }
+
+    int64_t elapsed_microseconds() {
+        using namespace std::chrono;
+        return duration_cast<microseconds>(t_end - t_start).count();
+    }
+
+   private:
+    std::chrono::time_point<std::chrono::system_clock> t_start;
+    std::chrono::time_point<std::chrono::system_clock> t_end;
+};
+
+template <typename T, typename Total, size_t N>
+class MovingAverage {
+   public:
+    MovingAverage& operator()(T sample) {
+        total_sum += sample;
+        if (samples_count < N)
+            samples[samples_count++] = sample;
+        else {
+            T& oldest = samples[samples_count++ % N];
+            total_sum -= oldest;
+            oldest = sample;
+        }
+        return *this;
+    }
+
+    operator double() const {
+        return static_cast<double>(total_sum) /
+               static_cast<double>(std::min(samples_count, N));
+    }
+
+   private:
+    T samples[N];
+    size_t samples_count{0};
+    Total total_sum{0};
+};
+
+using namespace ouster;
+
+// Same as ouster::cartesian but uses single float precision
+PointsF cartesian_f(const Eigen::Ref<const img_t<uint32_t>>& range,
+                    const PointsF& direction, const PointsF& offset) {
+    if (range.cols() * range.rows() != direction.rows())
+        throw std::invalid_argument("unexpected image dimensions");
+    auto reshaped = Eigen::Map<const Eigen::Array<uint32_t, -1, 1>>(
+        range.data(), range.cols() * range.rows());
+    auto nooffset = direction.colwise() * reshaped.cast<float>();
+    return (nooffset.array() == 0.0).select(nooffset, nooffset + offset);
+}
+
+
+class CarteianParamterizedTestFixture
+    : public ::testing::TestWithParam<std::pair<int, int>> {
+   protected:
+    int scan_width;
+    int scan_height;
+};
+
+INSTANTIATE_TEST_CASE_P(CarteianParamterizedTests,
+                        CarteianParamterizedTestFixture,
+                        ::testing::Values(std::pair<int, int>{512, 128},
+                                          std::pair<int, int>{1024, 128},
+                                          std::pair<int, int>{2048, 128},
+                                          std::pair<int, int>{4096, 128}));
+
+TEST(CarteianParamterizedTestFixture, CartesianFunctionsMatch) {
+    const auto WIDTH = 512;
+    const auto HEIGHT = 64;
+    const auto ROWS = WIDTH * HEIGHT;
+    const auto COLS = 3;
+
+    PointsD direction =
+        0.5 * PointsD::Random(ROWS, COLS) + PointsD::Constant(ROWS, COLS, 1.0);
+    PointsD offset = 0.005 * (PointsD::Random(ROWS, COLS) +
+                              PointsD::Constant(ROWS, COLS, 1.0));
+    XYZLut lut{direction, offset};
+
+    img_t<uint32_t> range = img_t<uint32_t>::Random(WIDTH, HEIGHT);
+
+    auto points0 = cartesian(range, lut);
+
+    PointsD points = PointsD::Zero(ROWS, COLS);
+
+    cartesianT(points, range, direction, offset);
+    EXPECT_TRUE(points.isApprox(points0));
+}
+
+TEST(CarteianParamterizedTestFixture, CartesianFunctionsMatchF) {
+    const auto WIDTH = 512;
+    const auto HEIGHT = 64;
+    const auto ROWS = WIDTH * HEIGHT;
+    const auto COLS = 3;
+
+    PointsD direction =
+        0.5 * PointsD::Random(ROWS, COLS) + PointsD::Constant(ROWS, COLS, 1.0);
+    PointsD offset = 0.005 * (PointsD::Random(ROWS, COLS) +
+                              PointsD::Constant(ROWS, COLS, 1.0));
+    XYZLut lut{direction, offset};
+
+    PointsF directionF = direction.cast<float>();
+    PointsF offsetF = offset.cast<float>();
+
+    img_t<uint32_t> range = img_t<uint32_t>::Random(WIDTH, HEIGHT);
+
+    auto points0 = cartesian(range, lut);
+    auto points0F = points0.cast<float>();
+
+    PointsF pointsF = PointsF::Zero(ROWS, COLS);
+
+    cartesianT(pointsF, range, directionF, offsetF);
+    EXPECT_TRUE(pointsF.isApprox(points0F));
+}
+
+TEST_P(CarteianParamterizedTestFixture, SpeedCheck) {
+    std::map<std::string, std::string> styles = {
+        {"red", "\033[0;31m"},     {"green", "\033[0;32m"},
+        {"yellow", "\033[0;33m"},  {"blue", "\033[0;34m"},
+        {"magenta", "\033[0;35m"}, {"cyan", "\033[0;36m"},
+        {"bold", "\033[1m"},       {"reset", "\033[0m"}};
+
+    const auto test_params = GetParam();
+    const auto WIDTH = test_params.first;
+    const auto HEIGHT = test_params.second;
+    const auto ROWS = WIDTH * HEIGHT;
+    const auto COLS = 3;
+    std::cout << styles["yellow"] << styles["bold"]
+              << "CHECKING PERFORMANCE FOR LIDAR MODE: [" << WIDTH << "x"
+              << HEIGHT << "]" << styles["reset"] << std::endl;
+
+    PointsD direction =
+        0.5 * PointsD::Random(ROWS, COLS) + PointsD::Constant(ROWS, COLS, 1.0);
+    PointsD offset = 0.005 * (PointsD::Random(ROWS, COLS) +
+                              PointsD::Constant(ROWS, COLS, 1.0));
+    XYZLut lut{direction, offset};
+
+    PointsF directionF = direction.cast<float>();
+    PointsF offsetF = offset.cast<float>();
+
+    // create an empty arrays of points
+    PointsD points = PointsD(ROWS, COLS);
+    PointsF pointsF = PointsF(ROWS, COLS);
+    img_t<uint32_t> range = img_t<uint32_t>(WIDTH, HEIGHT);
+
+    constexpr int N_SCANS = 1000;
+    constexpr int MOVING_AVG_WINDOW = 100;
+    using MovingAverage64 = MovingAverage<int64_t, int64_t, MOVING_AVG_WINDOW>;
+    static std::map<std::string, MovingAverage64> mv;
+
+    Timer t;
+    std::stringstream ss;
+    int output_ctr = 0;
+
+    using CartesianMethod = std::function<void(const img_t<uint32_t>& range)>;
+    std::vector<std::pair<std::string, CartesianMethod>> all_cartesians;
+
+    all_cartesians.emplace_back("c0", [&](const img_t<uint32_t>& range) {
+        points = cartesian(range, lut);
+    });
+
+    all_cartesians.emplace_back("c0f", [&](const img_t<uint32_t>& range) {
+        pointsF = cartesian_f(range, directionF, offsetF);
+    });
+
+    all_cartesians.emplace_back("cT", [&](const img_t<uint32_t>& range) {
+        cartesianT(points, range, direction, offset);
+    });
+
+    all_cartesians.emplace_back("cfT", [&](const img_t<uint32_t>& range) {
+        cartesianT(pointsF, range, directionF, offsetF);
+    });
+
+    std::default_random_engine g;
+    std::uniform_real_distribution<double> d(0.0, 1.0);
+    std::vector<int> ids(all_cartesians.size());
+    std::iota(std::begin(ids), std::end(ids), 0);
+
+    for (auto i = 0; i < N_SCANS; ++i) {
+        auto p = std::ceil(10 * float(i) / float(N_SCANS)) / 10;
+        auto unary_expr = [&g, &d, p](auto) {
+            return d(g) >= p ? 0U : static_cast<uint32_t>(d(g) * 10000);
+        };
+
+        auto valid_returns = (range != 0).count();
+        auto percentage_valid =
+            int(roundf(float(valid_returns) / float(range.size()) * 100));
+
+        std::shuffle(std::begin(ids), std::end(ids), g);
+        for (auto i : ids) {
+            const auto& method = all_cartesians[i];
+            range = range.unaryExpr(unary_expr);
+            t.start();
+            method.second(range);
+            t.stop();
+            mv[method.first](t.elapsed_microseconds());
+        }
+
+        if (++output_ctr % MOVING_AVG_WINDOW == 0) {
+            ss.str("");
+            ss << styles["bold"] << "returns: " << styles["reset"]
+               << styles["magenta"] << std::setw(3) << percentage_valid << "%, "
+               << styles["reset"];
+            ss << styles["bold"] << "c0[time]: " << styles["reset"]
+               << styles["cyan"] << std::setw(4) << mv["c0"] << "μs, "
+               << styles["reset"];
+
+            auto best_time = std::min_element(
+                mv.begin(), mv.end(), [](const auto& a, const auto& b) -> bool {
+                    return a.second < b.second;
+                });
+
+            for (const auto& x : mv) {
+                auto speedup = lround(100.0f * mv["c0"] / x.second);
+                auto color_modifier =
+                    x.first == best_time->first
+                        ? styles["blue"]
+                        : (speedup >= 100 ? styles["green"] : styles["red"]);
+                ss << styles["bold"] << x.first << ": " << color_modifier
+                   << std::setw(4) << speedup << "%, " << styles["reset"];
+            }
+            std::cout << ss.str() << std::endl;
+        }
+    }
+}


### PR DESCRIPTION
# Summary of Changes
- Introduced a new method `cartesianT` that provides better performance when projecting range images into 3D space
  - The new method offers 1.5x-4x speed up gain when compared to the current Eigen implementation
  - The method supports OpenMP when enabled through the compiler and explicitly requested by defining `OUSTER_OMP` flag
- Introduced a new unit test module `cartesian_test` which verifies the results

# Validation
- Not needed