### PR TITLE
Feature/multicast sdk

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+[unreleased]
+============
+
+ouster_client
+-------------
+- Added a new method ``mtp_init_client`` to init the client with multicast support (experimental).
+
+
 [20230114]
 ==========
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_executable(client_example client_example.cpp)
 target_link_libraries(client_example PRIVATE OusterSDK::ouster_client)
 
+add_executable(mtp_client_example mtp_client_example.cpp)
+target_link_libraries(mtp_client_example PRIVATE OusterSDK::ouster_client)
+
 add_executable(config_example config_example.cpp)
 target_link_libraries(config_example PRIVATE OusterSDK::ouster_client)
 

--- a/examples/mtp_client_example.cpp
+++ b/examples/mtp_client_example.cpp
@@ -1,0 +1,83 @@
+#include <iostream>
+
+#include "ouster/client.h"
+
+using namespace ouster;
+
+const size_t UDP_BUF_SIZE = 65536;
+
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        std::cerr << "\n\nUsage: <sensor_hostname> <main secondary>"
+                  << std::endl;
+
+        return argc == 1 ? EXIT_SUCCESS : EXIT_FAILURE;
+    }
+
+    const std::string sensor_hostname = argv[1];
+    // sensor::sensor_config config;
+
+    bool main = false;
+
+    if (std::string(argv[2]) == "main") {
+        main = true;
+    } else if (std::string(argv[2]) == "secondary") {
+        main = false;
+    } else {
+        std::cerr << "Invalid second argument: " << argv[2]
+                  << " only values of main or secondary are valid" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    sensor::sensor_config config;
+    if (!sensor::get_config(sensor_hostname, config)) {
+        std::cerr << "Failed to get sensor config" << std::endl;
+        return EXIT_FAILURE;
+    }
+    config.udp_dest = "239.201.201.201";
+    if (sensor::in_multicast(config.udp_dest.value())) {
+        std::cerr << "In multicast" << std::endl;
+    } else {
+        std::cerr << "Not a multicast address" << std::endl;
+        return -1;
+    }
+    std::shared_ptr<ouster::sensor::client> cli;
+    if (main) {
+        // This assumes a change to subscribe to IPADDR_ANY if not specified.
+        // Othewise you need to specify your own IP address such as
+        // cli = sensor::mtp_init_client_main(sensor_hostname, config,
+        // "192.168.1.11");
+        cli = sensor::mtp_init_client_main(sensor_hostname, config);
+    } else {
+        cli = sensor::mtp_init_client_secondary(sensor_hostname, config);
+    }
+    if (!cli) {
+        std::cerr << "Failed to initialize sensor" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    auto metadata = sensor::get_metadata(*cli);
+    sensor::sensor_info info = sensor::parse_metadata(metadata);
+    sensor::packet_format pf = sensor::get_format(info);
+    auto packet_buf = std::make_unique<uint8_t[]>(UDP_BUF_SIZE);
+
+    while (true) {
+        sensor::client_state st = sensor::poll_client(*cli);
+
+        if (st == sensor::TIMEOUT) {
+            std::cerr << "Timed out" << std::endl;
+            continue;
+        }
+        if (st & sensor::LIDAR_DATA) {
+            if (sensor::read_lidar_packet(*cli, packet_buf.get(), pf)) {
+                std::cerr << "Read Lidar Packet" << std::endl;
+            }
+        }
+
+        if (st & sensor::IMU_DATA) {
+            if (sensor::read_imu_packet(*cli, packet_buf.get(), pf)) {
+                std::cerr << "Read IMU packet" << std::endl;
+            }
+        }
+    }
+}

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -218,9 +218,12 @@ bool get_config(const std::string& hostname, sensor_config& config,
 enum config_flags : uint8_t {
     CONFIG_UDP_DEST_AUTO    = (1 << 0), ///< Set udp_dest automatically
     CONFIG_PERSIST          = (1 << 1), ///< Make configuration persistent
-    CONFIG_FORCE_REINIT     = (1 << 2)  ///< Forces the sensor to re-init during
+    CONFIG_FORCE_REINIT     = (1 << 2), ///< Forces the sensor to re-init during
                                         ///< set_config even when config params
                                         ///< have not changed
+    CONFIG_GET_ACTIVE       = (1 << 3)  ///< Get active config from sensor  
+                                        ///< without forcing any changes, need
+                                        ///< for mtp slave clients
 };
 // clang-format on
 

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -97,6 +97,31 @@ std::shared_ptr<client> init_client(const std::string& hostname,
                                     timestamp_mode ts_mode = TIME_FROM_UNSPEC,
                                     int lidar_port = 0, int imu_port = 0,
                                     int timeout_sec = 60);
+
+/**
+ * Connect to and configure the sensor and start listening for data.
+ *
+ * @param[in] hostname hostname or ip of the sensor.
+ * @param[in] mtp_group multicast ip address where the sensor should send data.
+ * @param[in] udp_dest_host ip address of host interface that should recieve multicast data.
+ * @param[in] ld_mode The lidar mode to use.
+ * @param[in] ts_mode The timestamp mode to use.
+ * @param[in] lidar_port port on which the sensor will send lidar data. When
+ * using zero the method will automatically acquire and assign any free port.
+ * @param[in] imu_port port on which the sensor will send imu data. When
+ * using zero the method will automatically acquire and assign any free port.
+ * @param[in] timeout_sec how long to wait for the sensor to initialize.
+ *
+ * @return pointer owning the resources associated with the connection.
+ */
+std::shared_ptr<client> init_client(const std::string& hostname,
+                                    const std::string& mtp_group,
+                                    const std::string& udp_dest_host,
+                                    lidar_mode ld_mode = MODE_UNSPEC,
+                                    timestamp_mode ts_mode = TIME_FROM_UNSPEC,
+                                    int lidar_port = 0, int imu_port = 0,
+                                    int timeout_sec = 60);
+
 /** @}*/
 
 /**

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -99,19 +99,6 @@ std::shared_ptr<client> init_client(const std::string& hostname,
                                     int timeout_sec = 60);
 
 /**
- * Connect to sensor and start listening for data via multicast.
- *
- * @param[in] hostname hostname or ip of the sensor. 
- * @param[in] config sensor config.
- * @param[in] mtp_dest_host multicast ip address where the sensor should send data.
- *
- * @return pointer owning the resources associated with the connection.
- */
-std::shared_ptr<client> mtp_init_client(const std::string& hostname,
-                                        const sensor_config& config,
-                                        const std::string& mtp_dest_host);
-
-/**
  * Connect to and configure the sensor and start listening for data via multicast.
  *
  * @param[in] hostname hostname or ip of the sensor. 
@@ -121,25 +108,11 @@ std::shared_ptr<client> mtp_init_client(const std::string& hostname,
  *
  * @return pointer owning the resources associated with the connection.
  */
-std::shared_ptr<client> mtp_init_client_main(const std::string& hostname,                                    
+std::shared_ptr<client> mtp_init_client(const std::string& hostname,                                    
                                              const sensor_config& config,
-                                             const std::string& mtp_dest_host = "",
+                                             const std::string& mtp_dest_host,
+                                             bool main,
                                              int timeout_sec = 60);
-
-
-/**
- * Listen for sensor data on the specified ports via multicast; do not configure the sensor.
- *
- * @param[in] hostname hostname or ip of the sensor. 
- * @param[in] config active sensor config from sensor.
- * @param[in] mtp_dest_host multicast ip address where the sensor should send data.
- * @param[in] timeout_sec how long to wait for the sensor to initialize.
- *
- * @return pointer owning the resources associated with the connection.
- */
-std::shared_ptr<client> mtp_init_client_secondary(const std::string& hostname,                                    
-                                                 const sensor_config& config,
-                                                 const std::string& mtp_dest_host = "");
 
 /** @}*/
 
@@ -218,12 +191,9 @@ bool get_config(const std::string& hostname, sensor_config& config,
 enum config_flags : uint8_t {
     CONFIG_UDP_DEST_AUTO    = (1 << 0), ///< Set udp_dest automatically
     CONFIG_PERSIST          = (1 << 1), ///< Make configuration persistent
-    CONFIG_FORCE_REINIT     = (1 << 2), ///< Forces the sensor to re-init during
+    CONFIG_FORCE_REINIT     = (1 << 2)  ///< Forces the sensor to re-init during
                                         ///< set_config even when config params
                                         ///< have not changed
-    CONFIG_GET_ACTIVE       = (1 << 3)  ///< Get active config from sensor  
-                                        ///< without forcing any changes, need
-                                        ///< for mtp slave clients
 };
 // clang-format on
 

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -260,5 +260,14 @@ int get_lidar_port(client& cli);
  */
 int get_imu_port(client& cli);
 
+/**
+ * Check if ip address in multicast range.
+ *
+ * @param[in] addr ip address to test.
+ *
+ * @return true if addr is in multicast range.
+ */
+bool in_multicast(const char* addr);
+
 }  // namespace sensor
 }  // namespace ouster

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -244,7 +244,7 @@ int get_imu_port(client& cli);
  *
  * @return true if addr is in multicast range.
  */
-bool in_multicast(const char* addr);
+bool in_multicast(const std::string& addr);
 
 }  // namespace sensor
 }  // namespace ouster

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -114,9 +114,9 @@ std::shared_ptr<client> init_client(const std::string& hostname,
  *
  * @return pointer owning the resources associated with the connection.
  */
-std::shared_ptr<client> init_client(const std::string& hostname,
-                                    const std::string& mtp_group,
+std::shared_ptr<client> init_client(const std::string& hostname,                                    
                                     const std::string& udp_dest_host,
+                                    const std::string& mtp_dest_host,
                                     lidar_mode ld_mode = MODE_UNSPEC,
                                     timestamp_mode ts_mode = TIME_FROM_UNSPEC,
                                     int lidar_port = 0, int imu_port = 0,

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -137,9 +137,9 @@ std::shared_ptr<client> mtp_init_client_main(const std::string& hostname,
  *
  * @return pointer owning the resources associated with the connection.
  */
-std::shared_ptr<client> mtp_init_client_slave(const std::string& hostname,                                    
-                                              const sensor_config& config,
-                                              const std::string& mtp_dest_host = "");
+std::shared_ptr<client> mtp_init_client_secondary(const std::string& hostname,                                    
+                                                 const sensor_config& config,
+                                                 const std::string& mtp_dest_host = "");
 
 /** @}*/
 

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -99,28 +99,47 @@ std::shared_ptr<client> init_client(const std::string& hostname,
                                     int timeout_sec = 60);
 
 /**
- * Connect to and configure the sensor and start listening for data.
+ * Connect to sensor and start listening for data via multicast.
  *
- * @param[in] hostname hostname or ip of the sensor.
- * @param[in] mtp_group multicast ip address where the sensor should send data.
- * @param[in] udp_dest_host ip address of host interface that should recieve multicast data.
- * @param[in] ld_mode The lidar mode to use.
- * @param[in] ts_mode The timestamp mode to use.
- * @param[in] lidar_port port on which the sensor will send lidar data. When
- * using zero the method will automatically acquire and assign any free port.
- * @param[in] imu_port port on which the sensor will send imu data. When
- * using zero the method will automatically acquire and assign any free port.
+ * @param[in] hostname hostname or ip of the sensor. 
+ * @param[in] config sensor config.
+ * @param[in] mtp_dest_host multicast ip address where the sensor should send data.
+ *
+ * @return pointer owning the resources associated with the connection.
+ */
+std::shared_ptr<client> mtp_init_client(const std::string& hostname,
+                                        const sensor_config& config,
+                                        const std::string& mtp_dest_host);
+
+/**
+ * Connect to and configure the sensor and start listening for data via multicast.
+ *
+ * @param[in] hostname hostname or ip of the sensor. 
+ * @param[in] config sensor config to set on sensor.
+ * @param[in] mtp_dest_host multicast ip address where the sensor should send data.
  * @param[in] timeout_sec how long to wait for the sensor to initialize.
  *
  * @return pointer owning the resources associated with the connection.
  */
-std::shared_ptr<client> init_client(const std::string& hostname,                                    
-                                    const std::string& udp_dest_host,
-                                    const std::string& mtp_dest_host,
-                                    lidar_mode ld_mode = MODE_UNSPEC,
-                                    timestamp_mode ts_mode = TIME_FROM_UNSPEC,
-                                    int lidar_port = 0, int imu_port = 0,
-                                    int timeout_sec = 60);
+std::shared_ptr<client> mtp_init_client_main(const std::string& hostname,                                    
+                                             const sensor_config& config,
+                                             const std::string& mtp_dest_host = "",
+                                             int timeout_sec = 60);
+
+
+/**
+ * Listen for sensor data on the specified ports via multicast; do not configure the sensor.
+ *
+ * @param[in] hostname hostname or ip of the sensor. 
+ * @param[in] config active sensor config from sensor.
+ * @param[in] mtp_dest_host multicast ip address where the sensor should send data.
+ * @param[in] timeout_sec how long to wait for the sensor to initialize.
+ *
+ * @return pointer owning the resources associated with the connection.
+ */
+std::shared_ptr<client> mtp_init_client_slave(const std::string& hostname,                                    
+                                              const sensor_config& config,
+                                              const std::string& mtp_dest_host = "");
 
 /** @}*/
 

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -99,20 +99,27 @@ std::shared_ptr<client> init_client(const std::string& hostname,
                                     int timeout_sec = 60);
 
 /**
- * Connect to and configure the sensor and start listening for data via multicast.
+ * [BETA] Connect to and configure the sensor and start listening for data via
+ * multicast.
  *
- * @param[in] hostname hostname or ip of the sensor. 
+ * @param[in] hostname hostname or ip of the sensor.
  * @param[in] config sensor config to set on sensor.
- * @param[in] mtp_dest_host multicast ip address where the sensor should send data.
+ * @param[in] mtp_dest_host multicast ip address where the sensor should send
+ * data.
+ * @param[in] main a flag that indicates this is the main connection to the
+ * sensor in an multicast setup.
  * @param[in] timeout_sec how long to wait for the sensor to initialize.
  *
  * @return pointer owning the resources associated with the connection.
+ *
+ * @remarks when main flag is set the config object will be used to configure
+ * the sensor, otherwise only the port values within the config object will be
+ * used and the rest will be ignored.
  */
-std::shared_ptr<client> mtp_init_client(const std::string& hostname,                                    
-                                             const sensor_config& config,
-                                             const std::string& mtp_dest_host,
-                                             bool main,
-                                             int timeout_sec = 60);
+std::shared_ptr<client> mtp_init_client(const std::string& hostname,
+                                        const sensor_config& config,
+                                        const std::string& mtp_dest_host,
+                                        bool main, int timeout_sec = 60);
 
 /** @}*/
 

--- a/ouster_client/include/ouster/types.h
+++ b/ouster_client/include/ouster/types.h
@@ -225,8 +225,6 @@ using ColumnWindow = std::pair<int, int>;
 struct sensor_config {
     optional<std::string> udp_dest;  ///< The destination address for the
                                      ///< lidar/imu data to be sent to
-    optional<std::string> mtp_dest;  ///< The host IP address of interfece for the
-                                     ///< lidar/imu data to be sent to via multicast
     optional<int> udp_port_lidar;    ///< The destination port for the lidar
                                      ///< data to be sent to
     optional<int> udp_port_imu;      ///< The destination port for the imu data

--- a/ouster_client/include/ouster/types.h
+++ b/ouster_client/include/ouster/types.h
@@ -225,8 +225,8 @@ using ColumnWindow = std::pair<int, int>;
 struct sensor_config {
     optional<std::string> udp_dest;  ///< The destination address for the
                                      ///< lidar/imu data to be sent to
-    optional<std::string> mtp_group; ///< The multicast group address for the
-                                     ///< lidar/imu data to be sent to
+    optional<std::string> mtp_dest;  ///< The host IP address of interfece for the
+                                     ///< lidar/imu data to be sent to via multicast
     optional<int> udp_port_lidar;    ///< The destination port for the lidar
                                      ///< data to be sent to
     optional<int> udp_port_imu;      ///< The destination port for the imu data

--- a/ouster_client/include/ouster/types.h
+++ b/ouster_client/include/ouster/types.h
@@ -225,6 +225,8 @@ using ColumnWindow = std::pair<int, int>;
 struct sensor_config {
     optional<std::string> udp_dest;  ///< The destination address for the
                                      ///< lidar/imu data to be sent to
+    optional<std::string> mtp_group; ///< The multicast group address for the
+                                     ///< lidar/imu data to be sent to
     optional<int> udp_port_lidar;    ///< The destination port for the lidar
                                      ///< data to be sent to
     optional<int> udp_port_imu;      ///< The destination port for the imu data

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -517,9 +517,9 @@ std::shared_ptr<client> mtp_init_client_main(const std::string& hostname,
     return cli;   
 }
 
-std::shared_ptr<client> mtp_init_client_slave(const std::string& hostname,                                    
-                                              const sensor_config& config,
-                                              const std::string& mtp_dest_host) {
+std::shared_ptr<client> mtp_init_client_secondary(const std::string& hostname,                                    
+                                                  const sensor_config& config,
+                                                  const std::string& mtp_dest_host) {
     logger().info("initialize client without sensor configuring: {} with ports: {}/{},"
                   "multicast group: {}", hostname, config.udp_port_lidar.value(),
                   config.udp_port_imu.value(), config.udp_dest.value());

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -154,7 +154,6 @@ SOCKET udp_data_socket(int port) {
     return SOCKET_ERROR;
 }
 
-
 SOCKET mtp_data_socket(int port, const std::string& udp_dest_host = "",
                        const std::string& mtp_dest_host = "") {
     struct addrinfo hints, *info_start, *ai;
@@ -176,12 +175,12 @@ SOCKET mtp_data_socket(int port, const std::string& udp_dest_host = "",
         return SOCKET_ERROR;
     }
 
-    for (auto preferred_af : {AF_INET}) { // TODO test with AF_INET6
+    for (auto preferred_af : {AF_INET}) {  // TODO test with AF_INET6
         for (ai = info_start; ai != NULL; ai = ai->ai_next) {
             if (ai->ai_family != preferred_af) continue;
 
             // choose first addrinfo where bind() succeeds
-            SOCKET sock_fd = 
+            SOCKET sock_fd =
                 socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
             if (!impl::socket_valid(sock_fd)) {
                 logger().warn("mtp socket(): {}", impl::socket_get_error());
@@ -195,24 +194,26 @@ SOCKET mtp_data_socket(int port, const std::string& udp_dest_host = "",
 
             if (::bind(sock_fd, ai->ai_addr, (socklen_t)ai->ai_addrlen)) {
                 logger().warn("mtp bind(): {}", impl::socket_get_error());
-                impl::socket_close(sock_fd);                
+                impl::socket_close(sock_fd);
                 continue;
             }
 
-            // bind() succeeded; join to multicast group on with preferred address
-            // connect only if addresses are not empty
+            // bind() succeeded; join to multicast group on with preferred
+            // address connect only if addresses are not empty
             if (!udp_dest_host.empty()) {
                 ip_mreq mreq;
                 mreq.imr_multiaddr.s_addr = inet_addr(udp_dest_host.c_str());
                 if (!mtp_dest_host.empty()) {
-                    mreq.imr_interface.s_addr = inet_addr(mtp_dest_host.c_str());
+                    mreq.imr_interface.s_addr =
+                        inet_addr(mtp_dest_host.c_str());
                 } else {
                     mreq.imr_interface.s_addr = htonl(INADDR_ANY);
                 }
 
-                if (setsockopt(sock_fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char*)&mreq,
-                            sizeof(mreq))) {
-                    logger().warn("mtp setsockopt(): {}", impl::socket_get_error());
+                if (setsockopt(sock_fd, IPPROTO_IP, IP_ADD_MEMBERSHIP,
+                               (char*)&mreq, sizeof(mreq))) {
+                    logger().warn("mtp setsockopt(): {}",
+                                  impl::socket_get_error());
                     impl::socket_close(sock_fd);
                     continue;
                 }

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -168,11 +168,11 @@ SOCKET mtp_data_socket(int port, const std::string& mtp_group = "",
 
     int ret = getaddrinfo(NULL, port_s.c_str(), &hints, &info_start);
     if (ret != 0) {
-        std::cerr << "udp getaddrinfo(): " << gai_strerror(ret) << std::endl;
+        logger().error("mtp getaddrinfo(): {}", gai_strerror(ret));
         return SOCKET_ERROR;
     }
     if (info_start == NULL) {
-        std::cerr << "udp getaddrinfo: empty result" << std::endl;
+        logger().error("mtp getaddrinfo(): empty result");
         return SOCKET_ERROR;
     }
 
@@ -188,7 +188,6 @@ SOCKET mtp_data_socket(int port, const std::string& mtp_group = "",
                 continue;
             }
 
-            int off = 0;
             if (impl::socket_set_reuse(sock_fd)) {
                 logger().warn("mtp socket_set_reuse(): {}",
                               impl::socket_get_error());
@@ -468,10 +467,9 @@ std::shared_ptr<client> init_client(const std::string& hostname,
 std::shared_ptr<client> init_client(const std::string& hostname,
                                     const std::string& mtp_group,
                                     const std::string& udp_dest_host,
-                                    lidar_mode ld_mode = MODE_UNSPEC,
-                                    timestamp_mode ts_mode = TIME_FROM_UNSPEC,
-                                    int lidar_port = 0, int imu_port = 0,
-                                    int timeout_sec = 60) {
+                                    lidar_mode ld_mode, timestamp_mode ts_mode,
+                                    int lidar_port, int imu_port,
+                                    int timeout_sec) {
 
     logger().info("initializing sensor: {} with ports: {}/{}, multicast group: {}",
                   hostname, lidar_port, imu_port, mtp_group);

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -576,7 +576,7 @@ int get_lidar_port(client& cli) { return get_sock_port(cli.lidar_fd); }
 
 int get_imu_port(client& cli) { return get_sock_port(cli.imu_fd); }
 
-bool in_multicast(const char* addr) { return IN_MULTICAST(ntohl(inet_addr(addr))); }
+bool in_multicast(const std::string& addr) { return IN_MULTICAST(ntohl(inet_addr(addr.c_str()))); }
 
 /**
  * Return the socket file descriptor used to listen for lidar UDP data.

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -489,7 +489,6 @@ std::shared_ptr<client> init_client(const std::string& hostname,
     try {
         sensor::sensor_config config;
         uint8_t config_flags = 0;
-        config.mtp_dest = mtp_dest_host;
         config.udp_dest = udp_dest_host;        
         if (ld_mode) config.ld_mode = ld_mode;
         if (ts_mode) config.ts_mode = ts_mode;

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -470,32 +470,34 @@ std::shared_ptr<client> init_client(const std::string& hostname,
     return cli;
 }
 
-std::shared_ptr<client> mtp_init_client_main(const std::string& hostname,                                    
-                                             const sensor_config& config,
-                                             const std::string& mtp_dest_host,
-                                             bool main,
-                                             int timeout_sec) {
-
-    logger().info("initializing sensor client: {} with ports: {}/{}, multicast group: {}",
-                  hostname, config.udp_port_lidar.value(), config.udp_port_imu.value(),
-                  config.udp_dest.value());
+std::shared_ptr<client> mtp_init_client(const std::string& hostname,
+                                        const sensor_config& config,
+                                        const std::string& mtp_dest_host,
+                                        bool main, int timeout_sec) {
+    logger().info(
+        "initializing sensor client: {} with ports: {}/{}, multicast group: {}",
+        hostname, config.udp_port_lidar.value(), config.udp_port_imu.value(),
+        config.udp_dest.value());
 
     auto cli = std::make_shared<client>();
     cli->hostname = hostname;
 
-    cli->lidar_fd = mtp_data_socket(config.udp_port_lidar.value(), config.udp_dest.value(), mtp_dest_host);
-    cli->imu_fd = mtp_data_socket(config.udp_port_imu.value()); // no need to join multicast group second time
+    cli->lidar_fd = mtp_data_socket(config.udp_port_lidar.value(),
+                                    config.udp_dest.value(), mtp_dest_host);
+    cli->imu_fd = mtp_data_socket(
+        config.udp_port_imu
+            .value());  // no need to join multicast group second time
 
     if (!impl::socket_valid(cli->lidar_fd) || !impl::socket_valid(cli->imu_fd))
         return std::shared_ptr<client>();
 
-    if (main) {        
+    if (main) {
         auto lidar_port = get_sock_port(cli->lidar_fd);
         auto imu_port = get_sock_port(cli->imu_fd);
 
         sensor_config config_copy{config};
         try {
-            uint8_t config_flags = 0;        
+            uint8_t config_flags = 0;
             if (lidar_port) config_copy.udp_port_lidar = lidar_port;
             if (imu_port) config_copy.udp_port_imu = imu_port;
             config_copy.operating_mode = OPERATING_NORMAL;
@@ -514,7 +516,7 @@ std::shared_ptr<client> mtp_init_client_main(const std::string& hostname,
         }
     }
 
-    return cli;   
+    return cli;
 }
 
 client_state poll_client(const client& c, const int timeout_sec) {

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -481,7 +481,7 @@ std::shared_ptr<client> mtp_init_client(const std::string& hostname,
 }
 
 std::shared_ptr<client> mtp_init_client_main(const std::string& hostname,                                    
-                                             sensor_config& config,
+                                             const sensor_config& config,
                                              const std::string& mtp_dest_host,
                                              int timeout_sec) {
 
@@ -494,12 +494,13 @@ std::shared_ptr<client> mtp_init_client_main(const std::string& hostname,
     auto lidar_port = get_sock_port(cli->lidar_fd);
     auto imu_port = get_sock_port(cli->imu_fd);
 
+    sensor_config config_copy{config};
     try {
         uint8_t config_flags = 0;        
-        if (lidar_port) config.udp_port_lidar = lidar_port;
-        if (imu_port) config.udp_port_imu = imu_port;
-        config.operating_mode = OPERATING_NORMAL;
-        set_config(hostname, config, config_flags);
+        if (lidar_port) config_copy.udp_port_lidar = lidar_port;
+        if (imu_port) config_copy.udp_port_imu = imu_port;
+        config_copy.operating_mode = OPERATING_NORMAL;
+        set_config(hostname, config_copy, config_flags);
 
         // will block until no longer INITIALIZING
         cli->meta = collect_metadata(hostname, timeout_sec);

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -154,6 +154,91 @@ SOCKET udp_data_socket(int port) {
     return SOCKET_ERROR;
 }
 
+
+SOCKET mtp_data_socket(int port, const std::string& mtp_group = "",
+                       const std::string& udp_dest_host = "") {
+    struct addrinfo hints, *info_start, *ai;
+
+    memset(&hints, 0, sizeof hints);
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_DGRAM;
+    hints.ai_flags = AI_PASSIVE;
+
+    auto port_s = std::to_string(port);
+
+    int ret = getaddrinfo(NULL, port_s.c_str(), &hints, &info_start);
+    if (ret != 0) {
+        std::cerr << "udp getaddrinfo(): " << gai_strerror(ret) << std::endl;
+        return SOCKET_ERROR;
+    }
+    if (info_start == NULL) {
+        std::cerr << "udp getaddrinfo: empty result" << std::endl;
+        return SOCKET_ERROR;
+    }
+
+    for (auto preferred_af : {AF_INET}) { // TODO test with AF_INET6
+        for (ai = info_start; ai != NULL; ai = ai->ai_next) {
+            if (ai->ai_family != preferred_af) continue;
+
+            // choose first addrinfo where bind() succeeds
+            SOCKET sock_fd = 
+                socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+            if (!impl::socket_valid(sock_fd)) {
+                logger().warn("mtp socket(): {}", impl::socket_get_error());
+                continue;
+            }
+
+            int off = 0;
+            if (impl::socket_set_reuse(sock_fd)) {
+                logger().warn("mtp socket_set_reuse(): {}",
+                              impl::socket_get_error());
+            }
+
+            if (::bind(sock_fd, ai->ai_addr, (socklen_t)ai->ai_addrlen)) {
+                logger().warn("mtp bind(): {}", impl::socket_get_error());
+                impl::socket_close(sock_fd);                
+                continue;
+            }
+
+            // bind() succeeded; join to multicast group on with preferred address
+            // connect only if addresses are not empty
+            if (!mtp_group.empty() && !mtp_group.empty()) {
+                ip_mreq mreq;
+                mreq.imr_multiaddr.s_addr = inet_addr(mtp_group.c_str());
+                mreq.imr_interface.s_addr = inet_addr(udp_dest_host.c_str());
+                if (setsockopt(sock_fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char*)&mreq,
+                            sizeof(mreq))) {
+                    logger().warn("mtp setsockopt(): {}", impl::socket_get_error());
+                    impl::socket_close(sock_fd);
+                    continue;
+                }
+            }
+
+            // join to multicast group succeeded; set some options and return
+            if (impl::socket_set_non_blocking(sock_fd)) {
+                logger().warn("mtp fcntl(): {}", impl::socket_get_error());
+                impl::socket_close(sock_fd);
+                continue;
+            }
+
+            if (setsockopt(sock_fd, SOL_SOCKET, SO_RCVBUF, (char*)&RCVBUF_SIZE,
+                           sizeof(RCVBUF_SIZE))) {
+                logger().warn("mtp setsockopt(): {}", impl::socket_get_error());
+                impl::socket_close(sock_fd);
+                continue;
+            }
+
+            freeaddrinfo(info_start);
+            return sock_fd;
+        }
+    }
+
+    // could not bind() a MTP server socket
+    freeaddrinfo(info_start);
+    logger().error("failed to bind mtp socket");
+    return SOCKET_ERROR;
+}
+
 Json::Value collect_metadata(const std::string& hostname, int timeout_sec) {
     auto sensor_http = SensorHttp::create(hostname);
     auto timeout_time =
@@ -378,6 +463,56 @@ std::shared_ptr<client> init_client(const std::string& hostname,
     }
 
     return cli;
+}
+
+std::shared_ptr<client> init_client(const std::string& hostname,
+                                    const std::string& mtp_group,
+                                    const std::string& udp_dest_host,
+                                    lidar_mode ld_mode = MODE_UNSPEC,
+                                    timestamp_mode ts_mode = TIME_FROM_UNSPEC,
+                                    int lidar_port = 0, int imu_port = 0,
+                                    int timeout_sec = 60) {
+
+    logger().info("initializing sensor: {} with ports: {}/{}, multicast group: {}",
+                  hostname, lidar_port, imu_port, mtp_group);
+
+    auto cli = std::make_shared<client>();
+    cli->hostname = hostname;
+
+    cli->lidar_fd = mtp_data_socket(lidar_port, mtp_group, udp_dest_host);
+    cli->imu_fd = mtp_data_socket(imu_port); // no need to join multicast group
+
+    if (!impl::socket_valid(cli->lidar_fd) || !impl::socket_valid(cli->imu_fd))
+        return std::shared_ptr<client>();
+
+    lidar_port = get_sock_port(cli->lidar_fd);
+    imu_port = get_sock_port(cli->imu_fd);
+
+    try {
+        sensor::sensor_config config;
+        uint8_t config_flags = 0;
+        config.mtp_group = mtp_group;
+        config.udp_dest = udp_dest_host;        
+        if (ld_mode) config.ld_mode = ld_mode;
+        if (ts_mode) config.ts_mode = ts_mode;
+        if (lidar_port) config.udp_port_lidar = lidar_port;
+        if (imu_port) config.udp_port_imu = imu_port;
+        config.operating_mode = OPERATING_NORMAL;
+        set_config(hostname, config, config_flags);
+
+        // will block until no longer INITIALIZING
+        cli->meta = collect_metadata(hostname, timeout_sec);
+        // check for sensor error states
+        auto status = cli->meta["sensor_info"]["status"].asString();
+        if (status == "ERROR" || status == "UNCONFIGURED")
+            return std::shared_ptr<client>();
+    } catch (const std::runtime_error& e) {
+        // log error message
+        logger().error("init_client(): {}", e.what());
+        return std::shared_ptr<client>();
+    }
+
+    return cli;   
 }
 
 client_state poll_client(const client& c, const int timeout_sec) {


### PR DESCRIPTION
Added multicast data receiver. To use this you need to set **udp_dest** on ouster configuration page to something like "239.xxx.xxx.xxx" and also set parameter **mtp_dest** in launch file to IP address of host interface where you want to receive multicast data (for adding this interface to multicast group). 

Tested on three Jetson Xavier and two Ouster OS-1 Rev D with FW 2.4

[Link](https://github.com/ouster-lidar/ouster-ros/pull/57) to corresponding PR in ros driver