### PR TITLE
Fix Networking Guide link.

### DIFF
--- a/docs/python/quickstart.rst
+++ b/docs/python/quickstart.rst
@@ -142,7 +142,7 @@ Now we have a ``source`` from our sensor! You're ready to record, visualize to v
 ``source`` in the Python :doc:`/python/examples/index`.
 
 
-.. _Networking Guide: https://static.ouster.dev/sensor-docs/developer_common_sections/networking-guide.html
+.. _Networking Guide: https://static.ouster.dev/sensor-docs/image_route1/image_route3/networking_guide/networking_guide.html
 
 
 Next Steps


### PR DESCRIPTION
The current Networking Guide link (https://static.ouster.dev/sensor-docs/developer_common_sections/networking-guide.html) doesn't seem to point to the correct webpage. I've changed it to this one --> https://static.ouster.dev/sensor-docs/image_route1/image_route3/networking_guide/networking_guide.html.