### PR TITLE
Fix required CMake version when CMAKE_CXX_COMPILER_LAUNCHER is defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,9 @@
+cmake_minimum_required(VERSION 3.10...3.22)
 if(DEFINED CMAKE_CXX_COMPILER_LAUNCHER )
-  cmake_minimum_required(VERSION 3.17...3.22)
   message("Using CXX Launcher: ${CMAKE_CXX_COMPILER_LAUNCHER}")
   if( DEFINED ENV{CCACHE_DIR} )
     message("Using CCACHE_DIR: $ENV{CCACHE_DIR}")
   endif()
-else()
-  cmake_minimum_required(VERSION 3.10...3.22)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
## Related Issues & PRs

The issue is introduced by the version 20231031 0.10.0
- https://github.com/ouster-lidar/ouster_example/pull/565

## Summary of Changes

This PR fixes minimum CMake version in CMakeLists.txt.
`CMAKE_CXX_COMPILER_LAUNCHER` CMake variable is available from version 3.4 according to the official documentation:
https://cmake.org/cmake/help/v3.4/variable/CMAKE_LANG_COMPILER_LAUNCHER.html#variable:CMAKE_%3CLANG%3E_COMPILER_LAUNCHER

## Validation

Checked that the `CMAKE_CXX_COMPILER_LAUNCHER` variable is properly picked up by CMake older than 3.17.
(Ubuntu 20.04, cmake 3.16.3)