### PR TITLE
Update curl_client.h

### DIFF
--- a/ouster_client/src/curl_client.h
+++ b/ouster_client/src/curl_client.h
@@ -88,12 +88,10 @@ class CurlClient : public ouster::util::HttpClient {
             if (attempts && 500 <= http_code && http_code < 600) {
                 // HTTP 5XX means a server error, so we should re-attempt.
                 // log a warning and sleep before re-attempting
-                ouster::sensor::logger().warn(
-                    std::string("Re-attempting CurlClient::execute_get after "
-                                "failure for url: ") +
-                        "[{}] with the code: [{}] - and return: {}",
-                    url, http_code, buffer);
-                std::this_thread::sleep_for(
+               ouster::sensor::logger().warn(
+                  "Re-attempting CurlClient::execute_get after failure for url: [{}] with the code: [{}] - and return: {}",
+                  url, http_code, buffer);
+                   std::this_thread::sleep_for(
                     std::chrono::milliseconds(retry_delay_ms));
             }
         }


### PR DESCRIPTION
Fixed bug with project building with catkin_make on ROS Melodic.

## Related Issues & PRs
Hello! We were unable to build the project for ROS Melodic with catkin_make. We have made a suggestion for a change for the following lines of code to make catkin_make be possible to build it. Thank you!

## Summary of Changes
Changed string concatenation in file `curl_client.h`.

## Validation
Build is valid in docker `nvidia/cudagl:11.4.2-runtime-ubuntu18.04` image with installed ROS Melodic and ouster packages.
