### PR TITLE
Fix non-const string issue with C++20

### DIFF
--- a/ouster_client/src/curl_client.h
+++ b/ouster_client/src/curl_client.h
@@ -89,9 +89,8 @@ class CurlClient : public ouster::util::HttpClient {
                 // HTTP 5XX means a server error, so we should re-attempt.
                 // log a warning and sleep before re-attempting
                 ouster::sensor::logger().warn(
-                    std::string("Re-attempting CurlClient::execute_get after "
-                                "failure for url: ") +
-                        "[{}] with the code: [{}] - and return: {}",
+                    "Re-attempting CurlClient::execute_get after failure for "
+                    "url: [{}] with the code: [{}] - and return: {}",
                     url, http_code, buffer);
                 std::this_thread::sleep_for(
                     std::chrono::milliseconds(retry_delay_ms));


### PR DESCRIPTION
Without this change, compiling with C++20 gives the following error due to the way std::string being used for the logging statement (which was not constexpr).

```
In file included from external/oustersdk/ouster_client/src/sensor_http_imp.cpp:3:
external/oustersdk/ouster_client/src/curl_client.h: In member function 'std::string CurlClient::execute_get(const string&, int, int) const':
external/oustersdk/ouster_client/src/curl_client.h:91:46: error: temporary of non-literal type 'std::__cxx11::basic_string<char>' in a constant expression
   91 |                 ouster::sensor::logger().warn(
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
   92 |                     std::string("Re-attempting CurlClient::execute_get after "
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   93 |                                 "failure for url: ") +
      |                                 ~~~~~~~~~~~~~~~~~~~~~~
   94 |                         "[{}] with the code: [{}] - and return: {}",
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   95 |                     url, http_code, buffer);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~   
In file included from /usr/include/c++/11/string:55,
                 from external/oustersdk/ouster_client/src/http_client.h:13,
                 from external/oustersdk/ouster_client/src/sensor_http_imp.h:12,
                 from external/oustersdk/ouster_client/src/sensor_http_imp.cpp:1:
/usr/include/c++/11/bits/basic_string.h:85:11: note: 'std::__cxx11::basic_string<char>' is not literal because:
   85 |     class basic_string
      |           ^~~~~~~~~~~~
/usr/include/c++/11/bits/basic_string.h:85:11: note:   'std::__cxx11::basic_string<char>' does not have 'constexpr' destructor
```