### PR TITLE
Fix path to header file

### DIFF
--- a/ouster_client/include/ouster/types.h
+++ b/ouster_client/include/ouster/types.h
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-#include "nonstd/optional.hpp"
+#include "optional-lite/nonstd/optional.hpp"
 #include "ouster/visibility.h"
 #include "version.h"
 


### PR DESCRIPTION

## Summary of Changes

Error when trying to include `types.h`

`fatal error: nonstd/optional.hpp: No such file or directory
         #include "nonstd/optional.hpp
`

Changing include path from 

`#include "nonstd/optional.hpp"
`
to 

`#include "optional-lite/nonstd/optional.hpp"
`
## Validation
