### PR TITLE
[fix] When building shared libraries all optional libraries are expected to be built

### DIFF
--- a/ouster_library/CMakeLists.txt
+++ b/ouster_library/CMakeLists.txt
@@ -50,10 +50,16 @@ set(OUSTER_LIBRARY_OBJECTS "")
 if(BUILD_SHARED_LIBRARY)
   # FIGURE OUT HOW TO SKIP VIZ OSF AND PCAP HERE
   add_library(shared_library SHARED
-    $<TARGET_OBJECTS:ouster_client>
-    $<$<TARGET_EXISTS:ouster_pcap>:$<TARGET_OBJECTS:ouster_pcap>>
-    $<$<TARGET_EXISTS:ouster_osf>:$<TARGET_OBJECTS:ouster_osf>>
-    $<$<TARGET_EXISTS:ouster_viz>:$<TARGET_OBJECTS:ouster_viz>>)
+    $<TARGET_OBJECTS:ouster_client>)
+  if(TARGET ouster_pcap)
+      target_sources(shared_library PRIVATE $<TARGET_OBJECTS:ouster_pcap>)
+  endif()
+  if(TARGET ouster_osf)
+      target_sources(shared_library PRIVATE $<TARGET_OBJECTS:ouster_osf>)
+  endif()
+  if(TARGET ouster_viz)
+      target_sources(shared_library PRIVATE $<TARGET_OBJECTS:ouster_viz>)
+  endif()
   ouster_library_common(shared_library)
   target_compile_definitions(shared_library PRIVATE BUILD_SHARED_LIBS_EXPORT)
 endif()


### PR DESCRIPTION
Hello! :wave: 

When reviewing the newest release 0.14.0 to be packaged in [Conan Center](https://conan.io/center), we found an error when building OusterSDK 0.14.0 as shared library, when optional modules like `ouster_pcap`, `ouster_osf`, `ouster_viz` are disabled, the `ouster_library/CMakeLists.txt` expects all targets be available to be added as dependency of `shared_library`:

My configure error log: 

<details>
<summary>Details</summary>

```
RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/home/conan/.conan2/p/b/ousteb2db7e7f8f39e/p" -DBUILD_VIZ="OFF" -DBUILD_PCAP="ON" -DBUILD_OSF="ON" -DOUSTER_USE_EIGEN_MAX_ALIGN_BYTES_32="OFF" -DCMAKE_POLICY_DEFAULT_CMP0077="NEW" -DBUILD_SHARED_LIBRARY="ON" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/home/conan/.conan2/p/b/ousteb2db7e7f8f39e/b/src"
-- Using Conan toolchain: /home/conan/.conan2/p/b/ousteb2db7e7f8f39e/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: C++ Standard 17 with extensions ON
-- Conan toolchain: Setting BUILD_SHARED_LIBS = ON
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Check for working C compiler: /usr/local/bin/cc
-- Check for working C compiler: /usr/local/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/local/bin/c++
-- Check for working CXX compiler: /usr/local/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Component target declared 'Eigen3::Eigen'
-- Conan: Component target declared 'CURL::libcurl'
-- Conan: Component target declared 'OpenSSL::Crypto'
-- Conan: Component target declared 'OpenSSL::SSL'
-- Conan: Target declared 'openssl::openssl'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Including build module from '/home/conan/.conan2/p/opens7abf84295e910/p/lib/cmake/conan-official-openssl-variables.cmake'
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Conan: Component target declared 'nonstd::optional-lite'
-- Found Pcap: /home/conan/.conan2/p/libpc6c92ab7790bb8/p/lib/libpcap.so  
-- Conan: Target declared 'libtins::libtins'
-- Conan: Component target declared 'Boost::diagnostic_definitions'
-- Conan: Component target declared 'Boost::disable_autolinking'
-- Conan: Component target declared 'Boost::dynamic_linking'
-- Conan: Component target declared 'boost::process'
-- Conan: Component target declared 'Boost::headers'
-- Conan: Component target declared 'Boost::boost'
-- Conan: Component target declared 'boost::_libboost'
-- Conan: Component target declared 'Boost::atomic'
-- Conan: Component target declared 'Boost::container'
-- Conan: Component target declared 'Boost::context'
-- Conan: Component target declared 'Boost::date_time'
-- Conan: Component target declared 'Boost::exception'
-- Conan: Component target declared 'Boost::math'
-- Conan: Component target declared 'Boost::program_options'
-- Conan: Component target declared 'Boost::regex'
-- Conan: Component target declared 'Boost::serialization'
-- Conan: Component target declared 'Boost::stacktrace'
-- Conan: Component target declared 'Boost::system'
-- Conan: Component target declared 'Boost::timer'
-- Conan: Component target declared 'Boost::chrono'
-- Conan: Component target declared 'Boost::coroutine'
-- Conan: Component target declared 'Boost::filesystem'
-- Conan: Component target declared 'Boost::json'
-- Conan: Component target declared 'Boost::math_c99'
-- Conan: Component target declared 'Boost::math_c99f'
-- Conan: Component target declared 'Boost::math_c99l'
-- Conan: Component target declared 'Boost::math_tr1'
-- Conan: Component target declared 'Boost::math_tr1f'
-- Conan: Component target declared 'Boost::math_tr1l'
-- Conan: Component target declared 'Boost::random'
-- Conan: Component target declared 'Boost::stacktrace_addr2line'
-- Conan: Component target declared 'Boost::stacktrace_backtrace'
-- Conan: Component target declared 'Boost::stacktrace_basic'
-- Conan: Component target declared 'Boost::stacktrace_noop'
-- Conan: Component target declared 'Boost::test'
-- Conan: Component target declared 'Boost::url'
-- Conan: Component target declared 'Boost::wserialization'
-- Conan: Component target declared 'Boost::fiber'
-- Conan: Component target declared 'Boost::graph'
-- Conan: Component target declared 'Boost::iostreams'
-- Conan: Component target declared 'Boost::nowide'
-- Conan: Component target declared 'Boost::prg_exec_monitor'
-- Conan: Component target declared 'Boost::test_exec_monitor'
-- Conan: Component target declared 'Boost::thread'
-- Conan: Component target declared 'Boost::wave'
-- Conan: Component target declared 'Boost::contract'
-- Conan: Component target declared 'Boost::fiber_numa'
-- Conan: Component target declared 'Boost::locale'
-- Conan: Component target declared 'Boost::log'
-- Conan: Component target declared 'Boost::type_erasure'
-- Conan: Component target declared 'Boost::unit_test_framework'
-- Conan: Component target declared 'Boost::log_setup'
-- Conan: Target declared 'boost::boost'
-- Conan: Target declared 'BZip2::BZip2'
-- Conan: Including build module from '/home/conan/.conan2/p/bzip21505bbbc20f2c/p/lib/cmake/conan-official-bzip2-variables.cmake'
-- Conan: Target declared 'libbacktrace::libbacktrace'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Component target declared 'OpenSSL::Crypto'
-- Conan: Component target declared 'OpenSSL::SSL'
-- Conan: Target declared 'openssl::openssl'
-- Conan: Including build module from '/home/conan/.conan2/p/opens7abf84295e910/p/lib/cmake/conan-official-openssl-variables.cmake'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Target declared 'PNG::PNG'
-- Conan: Component target declared 'Eigen3::Eigen'
-- Conan: Component target declared 'flatbuffers::libflatbuffers'
-- Conan: Target declared 'flatbuffers::flatbuffers'
-- Conan: Including build module from '/home/conan/.conan2/p/flatbbf0a5b7d842fe/p/lib/cmake/FlatcTargets.cmake'
-- Conan: Including build module from '/home/conan/.conan2/p/flatbbf0a5b7d842fe/p/lib/cmake/BuildFlatBuffers.cmake'
-- Conan: Component target declared 'Eigen3::Eigen'
Building Library: shared_library
Building Library: shared_library: Adding ouster_client
Building Library: shared_library: Adding ouster_pcap
Building Library: shared_library: Adding ouster_osf
-- Configuring done
CMake Error at ouster_library/CMakeLists.txt:52 (add_library):
  Error evaluating generator expression:

    $<TARGET_OBJECTS:ouster_viz>

  Objects of target "ouster_viz" referenced but no such target exists.


CMake Error at ouster_library/CMakeLists.txt:52 (add_library):
  No SOURCES given to target: shared_library

```

</details>

## Related Issues & PRs

Related issue when packaging the version 0.14.0: https://github.com/conan-io/conan-center-index/pull/26108

## Summary of Changes

Use CMake generator expression to validate first if the target of optional modules are available, and only link in case it exists.

## Validation

After applying my changes, the CMake setup no longer fails, in special, you can see the follow output:

```
Building Library: shared_library
Building Library: shared_library: Adding ouster_client
Building Library: shared_library: Adding ouster_pcap
Building Library: shared_library: Adding ouster_osf
```

My Cmake configure log: 

<details>
<summary>Details</summary>

```

RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/home/conan/.conan2/p/b/ouste7755828803fbd/p" -DBUILD_VIZ="OFF" -DBUILD_PCAP="ON" -DBUILD_OSF="ON" -DOUSTER_USE_EIGEN_MAX_ALIGN_BYTES_32="OFF" -DCMAKE_POLICY_DEFAULT_CMP0077="NEW" -DBUILD_SHARED_LIBRARY="ON" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/home/conan/.conan2/p/b/ouste7755828803fbd/b/src"
-- Using Conan toolchain: /home/conan/.conan2/p/b/ouste7755828803fbd/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: C++ Standard 17 with extensions ON
-- Conan toolchain: Setting BUILD_SHARED_LIBS = ON
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Check for working C compiler: /usr/local/bin/cc
-- Check for working C compiler: /usr/local/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/local/bin/c++
-- Check for working CXX compiler: /usr/local/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Component target declared 'Eigen3::Eigen'
-- Conan: Component target declared 'CURL::libcurl'
-- Conan: Component target declared 'OpenSSL::Crypto'
-- Conan: Component target declared 'OpenSSL::SSL'
-- Conan: Target declared 'openssl::openssl'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Including build module from '/home/conan/.conan2/p/opens7abf84295e910/p/lib/cmake/conan-official-openssl-variables.cmake'
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Conan: Component target declared 'nonstd::optional-lite'
-- Found Pcap: /home/conan/.conan2/p/libpc6c92ab7790bb8/p/lib/libpcap.so  
-- Conan: Target declared 'libtins::libtins'
-- Conan: Component target declared 'Boost::diagnostic_definitions'
-- Conan: Component target declared 'Boost::disable_autolinking'
-- Conan: Component target declared 'Boost::dynamic_linking'
-- Conan: Component target declared 'boost::process'
-- Conan: Component target declared 'Boost::headers'
-- Conan: Component target declared 'Boost::boost'
-- Conan: Component target declared 'boost::_libboost'
-- Conan: Component target declared 'Boost::atomic'
-- Conan: Component target declared 'Boost::container'
-- Conan: Component target declared 'Boost::context'
-- Conan: Component target declared 'Boost::date_time'
-- Conan: Component target declared 'Boost::exception'
-- Conan: Component target declared 'Boost::math'
-- Conan: Component target declared 'Boost::program_options'
-- Conan: Component target declared 'Boost::regex'
-- Conan: Component target declared 'Boost::serialization'
-- Conan: Component target declared 'Boost::stacktrace'
-- Conan: Component target declared 'Boost::system'
-- Conan: Component target declared 'Boost::timer'
-- Conan: Component target declared 'Boost::chrono'
-- Conan: Component target declared 'Boost::coroutine'
-- Conan: Component target declared 'Boost::filesystem'
-- Conan: Component target declared 'Boost::json'
-- Conan: Component target declared 'Boost::math_c99'
-- Conan: Component target declared 'Boost::math_c99f'
-- Conan: Component target declared 'Boost::math_c99l'
-- Conan: Component target declared 'Boost::math_tr1'
-- Conan: Component target declared 'Boost::math_tr1f'
-- Conan: Component target declared 'Boost::math_tr1l'
-- Conan: Component target declared 'Boost::random'
-- Conan: Component target declared 'Boost::stacktrace_addr2line'
-- Conan: Component target declared 'Boost::stacktrace_backtrace'
-- Conan: Component target declared 'Boost::stacktrace_basic'
-- Conan: Component target declared 'Boost::stacktrace_noop'
-- Conan: Component target declared 'Boost::test'
-- Conan: Component target declared 'Boost::url'
-- Conan: Component target declared 'Boost::wserialization'
-- Conan: Component target declared 'Boost::fiber'
-- Conan: Component target declared 'Boost::graph'
-- Conan: Component target declared 'Boost::iostreams'
-- Conan: Component target declared 'Boost::nowide'
-- Conan: Component target declared 'Boost::prg_exec_monitor'
-- Conan: Component target declared 'Boost::test_exec_monitor'
-- Conan: Component target declared 'Boost::thread'
-- Conan: Component target declared 'Boost::wave'
-- Conan: Component target declared 'Boost::contract'
-- Conan: Component target declared 'Boost::fiber_numa'
-- Conan: Component target declared 'Boost::locale'
-- Conan: Component target declared 'Boost::log'
-- Conan: Component target declared 'Boost::type_erasure'
-- Conan: Component target declared 'Boost::unit_test_framework'
-- Conan: Component target declared 'Boost::log_setup'
-- Conan: Target declared 'boost::boost'
-- Conan: Target declared 'BZip2::BZip2'
-- Conan: Including build module from '/home/conan/.conan2/p/bzip21505bbbc20f2c/p/lib/cmake/conan-official-bzip2-variables.cmake'
-- Conan: Target declared 'libbacktrace::libbacktrace'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Component target declared 'OpenSSL::Crypto'
-- Conan: Component target declared 'OpenSSL::SSL'
-- Conan: Target declared 'openssl::openssl'
-- Conan: Including build module from '/home/conan/.conan2/p/opens7abf84295e910/p/lib/cmake/conan-official-openssl-variables.cmake'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Target declared 'PNG::PNG'
-- Conan: Component target declared 'Eigen3::Eigen'
-- Conan: Component target declared 'flatbuffers::libflatbuffers'
-- Conan: Target declared 'flatbuffers::flatbuffers'
-- Conan: Including build module from '/home/conan/.conan2/p/flatbbf0a5b7d842fe/p/lib/cmake/FlatcTargets.cmake'
-- Conan: Including build module from '/home/conan/.conan2/p/flatbbf0a5b7d842fe/p/lib/cmake/BuildFlatBuffers.cmake'
-- Conan: Component target declared 'Eigen3::Eigen'
Building Library: shared_library
Building Library: shared_library: Adding ouster_client
Building Library: shared_library: Adding ouster_pcap
Building Library: shared_library: Adding ouster_osf
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_POLICY_DEFAULT_CMP0077


-- Build files have been written to: /home/conan/.conan2/p/b/ouste7755828803fbd/b/build/Release

ouster_sdk/0.14.0: Running CMake.build()
ouster_sdk/0.14.0: RUN: cmake --build "/home/conan/.conan2/p/b/ouste7755828803fbd/b/build/Release" -- -j12
Scanning dependencies of target ouster_generate_header
Scanning dependencies of target cpp_gen
Generating build info header
[  1%] Generating fb_binary_schemas/streaming/streaming_info.bfbs
[  3%] Generating fb_binary_schemas/chunk.bfbs
[  5%] Generating fb_source_generated/cpp/header_generated.h
[  6%] Generating fb_binary_schemas/header.bfbs
```

</details>
