### PR TITLE
Handle bag files with empty topics

### DIFF
--- a/python/src/ouster/sdk/bag/bag_packet_source.py
+++ b/python/src/ouster/sdk/bag/bag_packet_source.py
@@ -105,7 +105,7 @@ def bag2_monkey(self, paths, default_typestore=None):
     for id, c in f.channels.items():
         con = Connection(id = id, topic=c.topic, msgtype=c.schema,
                          msgdef=schemas[c.schema][1],
-                         msgcount = counts[id],
+                         msgcount = counts.get(id, 0),
                          ext = ConnectionExtRosbag2(serialization_format='cdr',
                                                     offered_qos_profiles=qos.get(c.schema, '')),
                          owner = self, digest = None)


### PR DESCRIPTION
## Summary of Changes
When reading an mcap file, make message count default to 0 if it's not in the mcap summary (when there are no messages).

## Validation
I have an mcap file without any messages in the `/ouster/os_driver/transition_event` topic. This is because the mcap file is split, midway through recording. When creating connections in the bag2_monkey function it pulls the message count for each channel from the summary, however the channel is missing from the summary message count. This causes a KeyError which erroneously reports that the MCAP file type is not supported in the `open_source` function (the KeyError comes from the handler function not the `io_type_handlers` lookup). After applying this change I was able to open the file and use the ouster-cli tools.