### PR TITLE
Fix clamping of key_eigen for Eigen 3.4.1

### DIFF
--- a/ouster_client/src/image_processing.cpp
+++ b/ouster_client/src/image_processing.cpp
@@ -130,7 +130,7 @@ void AutoExposure::update(Eigen::Ref<img_t<T>> image, bool update_state) {
     }
 
     // clamp
-    key_eigen = key_eigen.max(0.0).min(1.0);
+    key_eigen = key_eigen.cwiseMax(0.0).cwiseMin(1.0);
 
     if (update_state) {
         counter = (counter + 1) % ae_update_every;


### PR DESCRIPTION
## Related Issues & PRs

## Summary of Changes

When compiling with Eigen 3.4.1, it complains `image_processing.cpp:133:36: error: no member named 'min' in 'Eigen::CwiseBinaryOp<Eigen::internal::scalar_max_op<float>, const Eigen::Map<Eigen::Array<float, -1, 1>>, const double>'`.

This can be fixed by using the coefficient-wise operators: https://libeigen.gitlab.io/eigen/docs-nightly/group__QuickRefPage.html#:~:text=mat1.cwiseMin(mat2,mat1.cwiseMax(scalar).

Error:
```
In file included from external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:6:
In file included from external/_main~_repo_rules~ouster-sdk/ouster_client/include/ouster/image_processing.h:11:
In file included from external/eigen~/Eigen/Core:164:
external/eigen~/Eigen/src/Core/util/ForwardDeclarations.h:23:47: error: implicit instantiation of undefined template 'Eigen::internal::traits<double>'
   23 | template<typename T> struct traits<const T> : traits<T> {};
      |                                               ^
external/eigen~/Eigen/src/Core/CwiseBinaryOp.h:81:76: note: in instantiation of template class 'Eigen::internal::traits<const double>' requested here
   81 |                                                         typename internal::traits<RhsType>::StorageKind,
      |                                                                            ^
external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:133:27: note: in instantiation of template class 'Eigen::CwiseBinaryOp<Eigen::internal::scalar_max_op<float>, const Eigen::Map<Eigen::Array<float, -1, 1>>, const double>' requested here
  133 |     key_eigen = key_eigen.max(0.0).min(1.0);
      |                           ^
external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:143:5: note: in instantiation of function template specialization 'ouster::viz::AutoExposure::update<float>' requested here
  143 |     update(image, update_state);
      |     ^
external/eigen~/Eigen/src/Core/util/ForwardDeclarations.h:17:29: note: template is declared here
   17 | template<typename T> struct traits;
      |                             ^
In file included from external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:6:
In file included from external/_main~_repo_rules~ouster-sdk/ouster_client/include/ouster/image_processing.h:11:
In file included from external/eigen~/Eigen/Core:299:
external/eigen~/Eigen/src/Core/CwiseBinaryOp.h:94:74: error: implicit instantiation of undefined template 'Eigen::internal::traits<double>'
   94 |                                                       typename internal::traits<Rhs>::StorageKind,
      |                                                                          ^
external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:133:27: note: in instantiation of template class 'Eigen::CwiseBinaryOp<Eigen::internal::scalar_max_op<float>, const Eigen::Map<Eigen::Array<float, -1, 1>>, const double>' requested here
  133 |     key_eigen = key_eigen.max(0.0).min(1.0);
      |                           ^
external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:143:5: note: in instantiation of function template specialization 'ouster::viz::AutoExposure::update<float>' requested here
  143 |     update(image, update_state);
      |     ^
external/eigen~/Eigen/src/Core/util/ForwardDeclarations.h:17:29: note: template is declared here
   17 | template<typename T> struct traits;
      |                             ^
In file included from external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:6:
In file included from external/_main~_repo_rules~ouster-sdk/ouster_client/include/ouster/image_processing.h:11:
In file included from external/eigen~/Eigen/Core:299:
external/eigen~/Eigen/src/Core/CwiseBinaryOp.h:36:39: error: type 'const double' cannot be used prior to '::' because it has no members
   36 |                        const typename Rhs::Scalar&
      |                                       ^
external/eigen~/Eigen/src/Core/CwiseBinaryOp.h:96:5: note: in instantiation of template class 'Eigen::internal::traits<Eigen::CwiseBinaryOp<Eigen::internal::scalar_max_op<float>, const Eigen::Map<Eigen::Array<float, -1, 1>>, const double>>' requested here
   96 |     EIGEN_GENERIC_PUBLIC_INTERFACE(CwiseBinaryOp)
      |     ^
external/eigen~/Eigen/src/Core/util/Macros.h:1312:37: note: expanded from macro 'EIGEN_GENERIC_PUBLIC_INTERFACE'
 1312 |   typedef typename Eigen::internal::traits<Derived>::Scalar Scalar; /*!< \brief Numeric type, e.g. float, double, int or std::complex<float>. */ \
      |                                     ^
external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:133:27: note: in instantiation of template class 'Eigen::CwiseBinaryOp<Eigen::internal::scalar_max_op<float>, const Eigen::Map<Eigen::Array<float, -1, 1>>, const double>' requested here
  133 |     key_eigen = key_eigen.max(0.0).min(1.0);
      |                           ^
external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:143:5: note: in instantiation of function template specialization 'ouster::viz::AutoExposure::update<float>' requested here
  143 |     update(image, update_state);
      |     ^
In file included from external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:6:
In file included from external/_main~_repo_rules~ouster-sdk/ouster_client/include/ouster/image_processing.h:11:
In file included from external/eigen~/Eigen/Core:299:
external/eigen~/Eigen/src/Core/CwiseBinaryOp.h:40:69: error: no type named 'StorageKind' in 'Eigen::internal::traits<const double>'
   40 |                                               typename traits<Rhs>::StorageKind,
      |                                               ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
external/eigen~/Eigen/src/Core/CwiseBinaryOp.h:43:61: error: no type named 'StorageIndex' in 'Eigen::internal::traits<const double>'
   43 |                                       typename traits<Rhs>::StorageIndex>::type StorageIndex;
      |                                       ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
external/eigen~/Eigen/src/Core/CwiseBinaryOp.h:45:20: error: type 'const double' cannot be used prior to '::' because it has no members
   45 |   typedef typename Rhs::Nested RhsNested;
      |                    ^
external/eigen~/Eigen/src/Core/CwiseBinaryOp.h:49:97: error: no type named 'StorageKind' in 'Eigen::internal::traits<const double>'
   49 |     Flags = cwise_promote_storage_order<typename traits<Lhs>::StorageKind,typename traits<Rhs>::StorageKind,_LhsNested::Flags & RowMajorBit,_RhsNested::Flags & RowMajorBit>::value
      |                                                                           ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:133:36: error: no member named 'min' in 'Eigen::CwiseBinaryOp<Eigen::internal::scalar_max_op<float>, const Eigen::Map<Eigen::Array<float, -1, 1>>, const double>'
  133 |     key_eigen = key_eigen.max(0.0).min(1.0);
      |                 ~~~~~~~~~~~~~~~~~~ ^
external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:143:5: note: in instantiation of function template specialization 'ouster::viz::AutoExposure::update<float>' requested here
  143 |     update(image, update_state);
      |     ^
In file included from external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:6:
In file included from external/_main~_repo_rules~ouster-sdk/ouster_client/include/ouster/image_processing.h:11:
In file included from external/eigen~/Eigen/Core:286:
In file included from external/eigen~/Eigen/src/Core/ArrayBase.h:96:
external/eigen~/Eigen/src/Core/../plugins/ArrayCwiseBinaryOps.h:120:10: error: no viable conversion from returned value of type 'const CwiseBinaryOp<[2 * ...], const CwiseNullaryOp<internal::scalar_constant_op<Scalar>, PlainObject>>' to function return type 'const CwiseBinaryOp<[2 * ...], const double>'
  120 |   return (max<PropagateFast>)(other);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:133:27: note: in instantiation of function template specialization 'Eigen::ArrayBase<Eigen::Map<Eigen::Array<float, -1, 1>>>::max<double>' requested here
  133 |     key_eigen = key_eigen.max(0.0).min(1.0);
      |                           ^
external/_main~_repo_rules~ouster-sdk/ouster_client/src/image_processing.cpp:143:5: note: in instantiation of function template specialization 'ouster::viz::AutoExposure::update<float>' requested here
  143 |     update(image, update_state);
      |     ^
external/eigen~/Eigen/src/Core/util/ForwardDeclarations.h:91:65: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'const CwiseBinaryOp<internal::scalar_max_op<Scalar, Scalar, 0>, const Map<Array<float, -1, 1, 0, -1, 1>, 0, Stride<0, 0>>, const CwiseNullaryOp<internal::scalar_constant_op<Scalar>, PlainObject>>' (aka 'const CwiseBinaryOp<scalar_max_op<float, float, 0>, const Eigen::Map<Eigen::Array<float, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0>>, const CwiseNullaryOp<scalar_constant_op<float>, Eigen::Array<float, -1, 1, 0, -1, 1>>>') to 'const CwiseBinaryOp<scalar_max_op<float>, const Map<Array<float, -1, 1>>, const double> &' for 1st argument
   91 | template<typename BinaryOp,  typename Lhs, typename Rhs>  class CwiseBinaryOp;
      |                                                                 ^~~~~~~~~~~~~
external/eigen~/Eigen/src/Core/util/ForwardDeclarations.h:91:65: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'const CwiseBinaryOp<internal::scalar_max_op<Scalar, Scalar, 0>, const Map<Array<float, -1, 1, 0, -1, 1>, 0, Stride<0, 0>>, const CwiseNullaryOp<internal::scalar_constant_op<Scalar>, PlainObject>>' (aka 'const CwiseBinaryOp<scalar_max_op<float, float, 0>, const Eigen::Map<Eigen::Array<float, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0>>, const CwiseNullaryOp<scalar_constant_op<float>, Eigen::Array<float, -1, 1, 0, -1, 1>>>') to 'CwiseBinaryOp<scalar_max_op<float>, const Map<Array<float, -1, 1>>, const double> &&' for 1st argument
   91 | template<typename BinaryOp,  typename Lhs, typename Rhs>  class CwiseBinaryOp;
      |                                                                 ^~~~~~~~~~~~~
```

## Validation
