### PR TITLE
Add missing `<stdexcept>` include

### DIFF
--- a/ouster_client/include/ouster/impl/open_source_impl.h
+++ b/ouster_client/include/ouster/impl/open_source_impl.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <vector>
+#include <stdexcept>
 
 #include "nonstd/optional.hpp"
 #include "ouster/io_type.h"

--- a/ouster_client/src/io_type.cpp
+++ b/ouster_client/src/io_type.cpp
@@ -8,6 +8,7 @@
 
 #include <cstring>
 #include <string>
+#include <stdexcept>
 
 namespace ouster {
 namespace core {


### PR DESCRIPTION
Hi!

While trying to bring the latest version to Conan Center Index (PR: https://github.com/conan-io/conan-center-index/pull/28804) I found this problem:

The code uses `std::runtime_error` and `std::invalid_argument` in several places, but the required `<stdexcept>` header is not included. This causes compilation errors:

<details>

<summary>Details</summary>

```
-- Build files have been written to: /home/conan/.conan2/p/b/ouste26110ab2c0b98/b/build/Release

ouster_sdk/0.15.0: Running CMake.build()
ouster_sdk/0.15.0: RUN: cmake --build "/home/conan/.conan2/p/b/ouste26110ab2c0b98/b/build/Release" -- -j2
Generating build info header
[  1%] Generating fb_binary_schemas/streaming/streaming_info.bfbs
[  2%] Generating fb_source_generated/cpp/chunk_generated.h
[  2%] Built target ouster_generate_header
[  3%] Generating fb_binary_schemas/chunk.bfbs
[  4%] Generating fb_source_generated/cpp/header_generated.h
[  5%] Building CXX object ouster_client/CMakeFiles/ouster_client.dir/src/types.cpp.o
[  7%] Generating fb_binary_schemas/header.bfbs
[  8%] Generating fb_source_generated/cpp/metadata_generated.h
[  9%] Generating fb_binary_schemas/metadata.bfbs
[ 10%] Generating fb_source_generated/cpp/os_sensor/common_generated.h
[ 11%] Generating fb_binary_schemas/os_sensor/common.bfbs
[ 13%] Generating fb_source_generated/cpp/os_sensor/extrinsics_generated.h
[ 14%] Generating fb_binary_schemas/os_sensor/extrinsics.bfbs
[ 15%] Generating fb_source_generated/cpp/os_sensor/lidar_scan_stream_generated.h
[ 16%] Generating fb_binary_schemas/os_sensor/lidar_scan_stream.bfbs
[ 17%] Generating fb_source_generated/cpp/os_sensor/lidar_sensor_generated.h
[ 19%] Generating fb_binary_schemas/os_sensor/lidar_sensor.bfbs
[ 20%] Generating fb_source_generated/cpp/streaming/streaming_info_generated.h
[ 21%] Generating C++ code from Flatbuffers spec
[ 21%] Built target cpp_gen
[ 21%] Built target all_fb_gen
[ 22%] Building CXX object ouster_client/CMakeFiles/ouster_client.dir/src/sensor_info.cpp.o
[ 23%] Building CXX object ouster_client/CMakeFiles/ouster_client.dir/src/lidar_scan.cpp.o
[ 25%] Building CXX object ouster_client/CMakeFiles/ouster_client.dir/src/image_processing.cpp.o
[ 26%] Building CXX object ouster_client/CMakeFiles/ouster_client.dir/src/parsing.cpp.o
[ 27%] Building CXX object ouster_client/CMakeFiles/ouster_client.dir/src/packet_source.cpp.o
[ 28%] Building CXX object ouster_client/CMakeFiles/ouster_client.dir/src/compat_ops.cpp.o
[ 29%] Building CXX object ouster_client/CMakeFiles/ouster_client.dir/src/logging.cpp.o
[ 30%] Building CXX object ouster_client/CMakeFiles/ouster_client.dir/src/field.cpp.o
[ 32%] Building CXX object ouster_client/CMakeFiles/ouster_client.dir/src/profile_extension.cpp.o
[ 33%] Building CXX object ouster_client/CMakeFiles/ouster_client.dir/src/metadata.cpp.o
[ 34%] Building CXX object ouster_client/CMakeFiles/ouster_client.dir/src/packet.cpp.o
[ 35%] Building CXX object ouster_client/CMakeFiles/ouster_client.dir/src/open_source.cpp.o
In file included from /home/conan/.conan2/p/b/ouste26110ab2c0b98/b/src/ouster_client/include/ouster/open_source.h:11,
                 from /home/conan/.conan2/p/b/ouste26110ab2c0b98/b/src/ouster_client/src/open_source.cpp:6:
/home/conan/.conan2/p/b/ouste26110ab2c0b98/b/src/ouster_client/include/ouster/impl/open_source_impl.h: In member function 'void ouster::impl::Parameter<T>::check(const char*, const char*) const':
/home/conan/.conan2/p/b/ouste26110ab2c0b98/b/src/ouster_client/include/ouster/impl/open_source_impl.h:39:24: error: 'runtime_error' is not a member of 'std'
   39 |             throw std::runtime_error("Parameter '" + std::string(name) +
      |                        ^~~~~~~~~~~~~
/home/conan/.conan2/p/b/ouste26110ab2c0b98/b/src/ouster_client/include/ouster/impl/open_source_impl.h: In lambda function:
/home/conan/.conan2/p/b/ouste26110ab2c0b98/b/src/ouster_client/include/ouster/impl/open_source_impl.h:108:28: error: 'invalid_argument' is not a member of 'std'
  108 |                 throw std::invalid_argument(
      |                            ^~~~~~~~~~~~~~~~
/home/conan/.conan2/p/b/ouste26110ab2c0b98/b/src/ouster_client/include/ouster/impl/open_source_impl.h: In lambda function:
/home/conan/.conan2/p/b/ouste26110ab2c0b98/b/src/ouster_client/include/ouster/impl/open_source_impl.h:154:32: error: 'invalid_argument' is not a member of 'std'
  154 |                     throw std::invalid_argument(
      |                                ^~~~~~~~~~~~~~~~
ouster_client/CMakeFiles/ouster_client.dir/build.make:246: recipe for target 'ouster_client/CMakeFiles/ouster_client.dir/src/open_source.cpp.o' failed
make[2]: *** [ouster_client/CMakeFiles/ouster_client.dir/src/open_source.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
CMakeFiles/Makefile2:236: recipe for target 'ouster_client/CMakeFiles/ouster_client.dir/all' failed
make[1]: *** [ouster_client/CMakeFiles/ouster_client.dir/all] Error 2
Makefile:155: recipe for target 'all' failed
make: *** [all] Error 2

ouster_sdk/0.15.0: ERROR: 
Package '4c6a0e30783abc17b1ffffb25d379da0563a419b' build failed
ouster_sdk/0.15.0: WARN: Build folder /home/conan/.conan2/p/b/ouste26110ab2c0b98/b/build/Release
ERROR: ouster_sdk/0.15.0: Error in build() method, line 165
        cmake.build()
        ConanException: Error 2 while executing
```

</details>

This happens in:
- `ouster_client/include/ouster/impl/open_source_impl.h`: uses `std::runtime_error` and `std::invalid_argument`
- `ouster_client/src/io_type.cpp`: uses `std::invalid_argument`

The issue was masked because `optional-lite` (included via `nonstd/optional.hpp`) includes `<stdexcept>` when exceptions are enabled:

```
#if optional_CONFIG_NO_EXCEPTIONS
// already included: <cassert>
#else
# include <stdexcept>
#endif
```

So, if for any reason `optional_CONFIG_NO_EXCEPTIONS` has value `1` the compilation may fail.

## Solution

Add the missing `#include <stdexcept>` header to both files to ensures that `std::runtime_error` and `std::invalid_argument` are properly declared when used.
