### PR TITLE
Replaced clamping function

### DIFF
--- a/ouster_client/src/image_processing.cpp
+++ b/ouster_client/src/image_processing.cpp
@@ -130,7 +130,7 @@ void AutoExposure::update(Eigen::Ref<img_t<T>> image, bool update_state) {
     }
 
     // clamp
-    key_eigen = key_eigen.max(0.0).min(1.0);
+    key_eigen = key_eigen.cwiseMax(0.0).cwiseMin(1.0);
 
     if (update_state) {
         counter = (counter + 1) % ae_update_every;


### PR DESCRIPTION
Hello!

While working on NixOS I was running into compilation issues with this sdk. I narrowed it down to this clamping function which seems to have some sort of templating issue leading to compilation failure.

I believe this updated clamping function should be equivalent and more clearly operating element wise but I have not had the chance to validate this, only to confirm that it now builds on NixOS and still builds in an Ubuntu docker image.

My main use for this sdk is within the ouster_ros library. I intend to propagate this change into the ouster_ros repo (specifically the branches that no longer use this repo as a submodule like rolling-devel) but I thought that this would be the best place to get this update validated.