### PR TITLE
WIP: C and C# bindings for ouster-sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ rules.ninja
 *.a
 **/_build
 clang-tidy-output.{txt,json}
+
+# CSharp build artifacts
+c_sharp/bin/
+c_sharp/obj/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ option(BUILD_EXAMPLES "Build C++ examples" OFF)
 option(OUSTER_USE_EIGEN_MAX_ALIGN_BYTES_32 "Eigen max aligned bytes." OFF)
 option(BUILD_SHARED_LIBRARY "Build shared Library." OFF)
 option(BUILD_DEBIAN_FOR_GITHUB "Build debian for github ci" OFF)
+option(BUILD_C_WRAPPER "Build C wrapper library." ON)
 
 # when building as a top-level project
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
@@ -87,6 +88,11 @@ endif()
 
 if(BUILD_MAPPING)
   add_subdirectory(ouster_mapping)
+endif()
+
+if(BUILD_C_WRAPPER)
+  # Place before examples so examples can link to ouster_c
+  add_subdirectory(ouster_c)
 endif()
 
 if(BUILD_EXAMPLES)

--- a/c_sharp/NativeMethods.cs
+++ b/c_sharp/NativeMethods.cs
@@ -83,10 +83,13 @@ internal static class NativeMethods
     internal static extern void ouster_lidar_scan_get_dimensions(IntPtr scan, out int width, out int height);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
-    internal static extern int ouster_lidar_scan_get_field_u32(IntPtr scan, string field_name, IntPtr out_buf, UIntPtr capacity, out UIntPtr out_count);
+    internal static extern int ouster_lidar_scan_get_field_u32(IntPtr scan, string field_name, int destagger, IntPtr out_buf, UIntPtr capacity, out UIntPtr out_count);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
-    internal static extern int ouster_lidar_scan_get_field_u16(IntPtr scan, string field_name, IntPtr out_buf, UIntPtr capacity, out UIntPtr out_count);
+    internal static extern int ouster_lidar_scan_get_field_u16(IntPtr scan, string field_name, int destagger, IntPtr out_buf, UIntPtr capacity, out UIntPtr out_count);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_lidar_scan_get_field_u8(IntPtr scan, string field_name, int destagger, IntPtr out_buf, UIntPtr capacity, out UIntPtr out_count);
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int ouster_lidar_scan_get_xyz(IntPtr scan, IntPtr lut, IntPtr xyz_out, UIntPtr capacity_points, out UIntPtr out_points, int filter_invalid);

--- a/c_sharp/NativeMethods.cs
+++ b/c_sharp/NativeMethods.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace OusterSdkCSharp;
+
+internal static class NativeConstants
+{
+    public const int OU_CLIENT_TIMEOUT = 0;
+    public const int OU_CLIENT_ERROR = 1;
+    public const int OU_CLIENT_LIDAR_DATA = 2;
+    public const int OU_CLIENT_IMU_DATA = 4;
+    public const int OU_CLIENT_EXIT = 8;
+}
+
+internal static class NativeMethods
+{
+    private const string LinuxLib = "ouster_c"; // resolves to libouster_c.so
+    private const string MacLib = "ouster_c";   // resolves to libouster_c.dylib
+    private const string WindowsLib = "ouster_c"; // ouster_c.dll
+
+#if WINDOWS
+    private const string Lib = WindowsLib;
+#elif OSX
+    private const string Lib = MacLib;
+#else
+    private const string Lib = LinuxLib;
+#endif
+
+    // Client API
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern IntPtr ouster_client_create(string hostname, int lidar_port, int imu_port);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void ouster_client_destroy(IntPtr client);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_client_poll(IntPtr client, int timeout_sec);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_client_get_metadata(IntPtr client, IntPtr buffer, UIntPtr capacity);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_client_fetch_and_parse_metadata(IntPtr client, int timeout_sec);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_client_get_frame_dimensions(IntPtr client, out int width, out int height);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_client_get_packet_sizes(IntPtr client, out UIntPtr lidar_packet_size, out UIntPtr imu_packet_size);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_client_read_lidar_packet(IntPtr client, IntPtr buf, UIntPtr buf_size);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_client_read_imu_packet(IntPtr client, IntPtr buf, UIntPtr buf_size);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_client_get_lidar_port(IntPtr client);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_client_get_imu_port(IntPtr client);
+
+    // Scan Source API
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_scan_source_create(string hostname, out IntPtr out_source);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void ouster_scan_source_destroy(IntPtr source);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_scan_source_frame_dimensions(IntPtr source, out int width, out int height);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_scan_source_get_metadata(IntPtr source, IntPtr buffer, UIntPtr capacity);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern IntPtr ouster_scan_source_next_scan(IntPtr source, int timeout_sec);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void ouster_lidar_scan_destroy(IntPtr scan);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void ouster_lidar_scan_get_dimensions(IntPtr scan, out int width, out int height);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_lidar_scan_get_field_u32(IntPtr scan, string field_name, IntPtr out_buf, UIntPtr capacity, out UIntPtr out_count);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_lidar_scan_get_field_u16(IntPtr scan, string field_name, IntPtr out_buf, UIntPtr capacity, out UIntPtr out_count);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ouster_lidar_scan_get_xyz(IntPtr scan, IntPtr lut, IntPtr xyz_out, UIntPtr capacity_points, out UIntPtr out_points, int filter_invalid);
+
+    // XYZ LUT API
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern IntPtr ouster_scan_source_create_xyz_lut(IntPtr source, int use_extrinsics);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void ouster_xyz_lut_destroy(IntPtr lut);
+}

--- a/c_sharp/OusterClient.cs
+++ b/c_sharp/OusterClient.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace OusterSdkCSharp;
+
+public sealed class OusterClient : IDisposable
+{
+    public IntPtr Handle { get; private set; }
+    public bool IsValid => Handle != IntPtr.Zero;
+
+    public static OusterClient? Create(string hostname, int lidarPort = 0, int imuPort = 0)
+    {
+        var h = NativeMethods.ouster_client_create(hostname, lidarPort, imuPort);
+        return h == IntPtr.Zero ? null : new OusterClient(h);
+    }
+
+    private OusterClient(IntPtr handle) => Handle = handle;
+
+    public int FetchAndParseMetadata(int timeoutSec = 30) => NativeMethods.ouster_client_fetch_and_parse_metadata(Handle, timeoutSec);
+
+    public string GetMetadata()
+    {
+        int len = NativeMethods.ouster_client_get_metadata(Handle, IntPtr.Zero, UIntPtr.Zero);
+        if (len <= 0) return string.Empty;
+        var buf = Marshal.AllocHGlobal(len + 1);
+        try
+        {
+            NativeMethods.ouster_client_get_metadata(Handle, buf, (UIntPtr)(ulong)(len + 1));
+            return Marshal.PtrToStringAnsi(buf) ?? string.Empty;
+        }
+        finally { Marshal.FreeHGlobal(buf); }
+    }
+
+    public (int Width, int Height) GetFrameDimensions()
+    {
+        NativeMethods.ouster_client_get_frame_dimensions(Handle, out int w, out int h);
+        return (w, h);
+    }
+
+    public (ulong LidarPacketSize, ulong ImuPacketSize) GetPacketSizes()
+    {
+        NativeMethods.ouster_client_get_packet_sizes(Handle, out UIntPtr lidar, out UIntPtr imu);
+        return ((ulong)lidar, (ulong)imu);
+    }
+
+    public int Poll(int timeoutSec = 1) => NativeMethods.ouster_client_poll(Handle, timeoutSec);
+
+    public byte[]? ReadLidarPacket()
+    {
+        var sizes = GetPacketSizes();
+        if (sizes.LidarPacketSize == 0) return null;
+        var arr = new byte[sizes.LidarPacketSize];
+        var ptr = Marshal.AllocHGlobal(arr.Length);
+        try
+        {
+            int ok = NativeMethods.ouster_client_read_lidar_packet(Handle, ptr, (UIntPtr)(ulong)arr.Length);
+            if (ok == 1) Marshal.Copy(ptr, arr, 0, arr.Length);
+            return ok == 1 ? arr : null;
+        }
+        finally { Marshal.FreeHGlobal(ptr); }
+    }
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            NativeMethods.ouster_client_destroy(Handle);
+            Handle = IntPtr.Zero;
+        }
+        GC.SuppressFinalize(this);
+    }
+}

--- a/c_sharp/OusterScanSource.cs
+++ b/c_sharp/OusterScanSource.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace OusterSdkCSharp;
+
+public sealed class OusterLidarScan : IDisposable
+{
+    internal IntPtr Handle { get; private set; }
+    internal XYZLut Lut { get; private set; }
+
+    internal int Width { get; private set; }
+    internal int Height { get; private set; }
+
+    internal OusterLidarScan(IntPtr handle, XYZLut lut)
+    {
+        Handle = handle;
+        Lut = lut;
+        NativeMethods.ouster_lidar_scan_get_dimensions(Handle, out int w, out int h);
+        Width = w;
+        Height = h;
+    }
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            NativeMethods.ouster_lidar_scan_destroy(Handle);
+            Handle = IntPtr.Zero;
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    public float[] GetXYZ(bool filterInvalid)
+    {
+        ulong maxPoints = (ulong)Width * (ulong)Height;
+        var xyz = new float[maxPoints * 3];
+        var ptr = Marshal.AllocHGlobal(sizeof(float) * (int)(maxPoints * 3));
+        try
+        {
+            int rc = NativeMethods.ouster_lidar_scan_get_xyz(
+                Handle, Lut.Handle, ptr, (UIntPtr)maxPoints, out var outPoints, filterInvalid ? 1 : 0);
+            if (rc != 0) return Array.Empty<float>();
+            int n = (int)outPoints;
+            Marshal.Copy(ptr, xyz, 0, (int)(n * 3));
+            if (n * 3 < xyz.Length)
+            {
+                Array.Resize(ref xyz, (int)(n * 3));
+            }
+            return xyz;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(ptr);
+        }
+    }
+
+    public uint[] GetRange()
+    {
+        ulong count = (ulong)Width * (ulong)Height;
+        var managed = new int[count];
+        var ptr = Marshal.AllocHGlobal(sizeof(uint) * (int)count);
+        try
+        {
+            int rc = NativeMethods.ouster_lidar_scan_get_field_u32(
+                Handle, "RANGE", ptr, (UIntPtr)count, out var outCount);
+            if (rc != 0) return Array.Empty<uint>();
+            Marshal.Copy(ptr, managed, 0, (int)outCount);
+            return Array.ConvertAll(managed, item => (uint)item);
+        }
+        finally { Marshal.FreeHGlobal(ptr); }
+    }
+
+    public ushort[] GetReflectivity(OusterLidarScan scan)
+    {
+        ulong count = (ulong)Width * (ulong)Height;
+        var managed = new short[count];
+        var ptr = Marshal.AllocHGlobal(sizeof(ushort) * (int)count);
+        try
+        {
+            int rc = NativeMethods.ouster_lidar_scan_get_field_u16(scan.Handle, "REFLECTIVITY", ptr, (UIntPtr)count, out var outCount);
+            if (rc != 0) return Array.Empty<ushort>();
+            Marshal.Copy(ptr, managed, 0, (int)outCount);
+            return Array.ConvertAll(managed, item => (ushort)item);
+        }
+        finally { Marshal.FreeHGlobal(ptr); }
+    }
+}
+
+public sealed class XYZLut : IDisposable
+{
+    internal IntPtr Handle { get; private set; }
+
+    internal XYZLut(IntPtr handle)
+    {
+        Handle = handle;
+    }
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            NativeMethods.ouster_xyz_lut_destroy(Handle);
+            Handle = IntPtr.Zero;
+        }
+        GC.SuppressFinalize(this);
+    }
+}
+
+public sealed class OusterScanSource : IDisposable
+{
+    public IntPtr Handle { get; private set; }
+    private int _width;
+    private int _height;
+    public int Width => _width;
+    public int Height => _height;
+
+    private XYZLut _lut = null!;
+
+    public static OusterScanSource? Create(string hostname)
+    {
+        int rc = NativeMethods.ouster_scan_source_create(hostname, out var handle);
+        if (rc != 0 || handle == IntPtr.Zero) return null;
+        var src = new OusterScanSource(handle);
+        src.RefreshDimensions();
+        src._lut = src.CreateXYZLut();
+        return src;
+    }
+
+    public XYZLut CreateXYZLut(bool useExtrinsics = true)
+    {
+        int flag = useExtrinsics ? 1 : 0;
+        var lutPtr = NativeMethods.ouster_scan_source_create_xyz_lut(Handle, flag);
+        return new XYZLut(lutPtr);
+    }
+
+    private OusterScanSource(IntPtr h) => Handle = h;
+
+    private void RefreshDimensions()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            NativeMethods.ouster_scan_source_frame_dimensions(Handle, out _width, out _height);
+        }
+    }
+
+    public string GetMetadata()
+    {
+        int len = NativeMethods.ouster_scan_source_get_metadata(Handle, IntPtr.Zero, UIntPtr.Zero);
+        if (len <= 0) return string.Empty;
+        var buf = Marshal.AllocHGlobal(len + 1);
+        try
+        {
+            NativeMethods.ouster_scan_source_get_metadata(Handle, buf, (UIntPtr)(ulong)(len + 1));
+            return Marshal.PtrToStringAnsi(buf) ?? string.Empty;
+        }
+        finally { Marshal.FreeHGlobal(buf); }
+    }
+
+    public OusterLidarScan? NextScan(int timeoutSec = 2)
+    {
+        var scanPtr = NativeMethods.ouster_scan_source_next_scan(Handle, timeoutSec);
+        return scanPtr == IntPtr.Zero ? null : new OusterLidarScan(scanPtr, _lut);
+    }
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            NativeMethods.ouster_scan_source_destroy(Handle);
+            Handle = IntPtr.Zero;
+        }
+        GC.SuppressFinalize(this);
+    }
+}

--- a/c_sharp/OusterSdkCSharp.csproj
+++ b/c_sharp/OusterSdkCSharp.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>OusterSdkCSharp</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" Pack="false" />

--- a/c_sharp/OusterSdkCSharp.csproj
+++ b/c_sharp/OusterSdkCSharp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>OusterSdkCSharp</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="false" />
+  </ItemGroup>
+</Project>

--- a/c_sharp/Program.cs
+++ b/c_sharp/Program.cs
@@ -36,9 +36,9 @@ internal static class Program
                 continue;
             }
             var xyz = scan.GetXYZ(filterInvalid: true);
-            var range = scan.GetRange();
+            var range = scan.GetFieldU32("RANGE");
             Console.WriteLine(
-                $"Scan {scansGot}: points={xyz.Length / 3}, rangeSample=[{string.Join(' ', range.Take(8))} ...]");
+                $"Scan {scansGot}: points={xyz.Length / 3}, rangeSample=[{string.Join(' ', range.Cast<uint>().Take(8))} ...]");
 
             var fname = $"cs_cloud_{scansGot}.csv";
             using var sw = new StreamWriter(fname);

--- a/c_sharp/Program.cs
+++ b/c_sharp/Program.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using OusterSdkCSharp;
+
+internal static class Program
+{
+    private const int ScansNeeded = 5;
+
+    public static void Main(string[] args)
+    {
+        if (args.Length < 1)
+        {
+            Console.Error.WriteLine("Usage: dotnet run --project c_sharp <sensor_hostname>");
+            return;
+        }
+        var hostname = args[0];
+
+        using var source = OusterScanSource.Create(hostname);
+        if (source is null)
+        {
+            Console.Error.WriteLine("Failed to create scan source");
+            return;
+        }
+
+        Console.WriteLine($"Frame dimensions: {source.Width}x{source.Height}");
+
+        int scansGot = 0;
+        while (scansGot < ScansNeeded)
+        {
+            using var scan = source.NextScan(2);
+            if (scan is null)
+            {
+                Console.WriteLine("Timeout waiting for scan...");
+                continue;
+            }
+            var xyz = scan.GetXYZ(filterInvalid: true);
+            var range = scan.GetRange();
+            Console.WriteLine(
+                $"Scan {scansGot}: points={xyz.Length / 3}, rangeSample=[{string.Join(' ', range.Take(8))} ...]");
+
+            var fname = $"cs_cloud_{scansGot}.csv";
+            using var sw = new StreamWriter(fname);
+            sw.WriteLine("x,y,z");
+            for (int i = 0; i < xyz.Length; i += 3)
+            {
+                sw.WriteLine(string.Create(CultureInfo.InvariantCulture, $"{xyz[i]},{xyz[i+1]},{xyz[i+2]}"));
+            }
+            Console.WriteLine($"Wrote {fname}");
+            ++scansGot;
+        }
+        Console.WriteLine("Done.");
+    }
+}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -48,3 +48,14 @@ endif()
 
 add_executable(scan_source_example scan_source_example.cpp)
 target_link_libraries(scan_source_example PRIVATE OusterSDK::ouster_osf OusterSDK::ouster_sensor)
+
+# C wrapper examples (pure C)
+if(TARGET ouster_c)
+  add_executable(c_client_example c_client_example.c)
+  target_link_libraries(c_client_example PRIVATE ouster_c)
+
+  add_executable(c_scan_source_example c_scan_source_example.c)
+  target_link_libraries(c_scan_source_example PRIVATE ouster_c)
+else()
+  message(STATUS "C wrapper library not built; skipping C examples")
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -52,7 +52,7 @@ target_link_libraries(scan_source_example PRIVATE OusterSDK::ouster_osf OusterSD
 # C wrapper examples (pure C)
 if(TARGET ouster_c)
   add_executable(c_client_example c_client_example.c)
-  target_link_libraries(c_client_example PRIVATE ouster_c)
+  target_link_libraries(c_client_example PRIVATE OusterSDK::ouster_client ouster_c)
 
   add_executable(c_scan_source_example c_scan_source_example.c)
   target_link_libraries(c_scan_source_example PRIVATE ouster_c)

--- a/examples/c_client_example.c
+++ b/examples/c_client_example.c
@@ -1,0 +1,81 @@
+/*
+ * Minimal pure-C example using the C wrapper library (ouster_c).
+ * Connects to a sensor, fetches metadata, prints basic info, then polls
+ * and reads a handful of lidar packets.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ouster_c.h"
+
+int main(int argc, char** argv) {
+    if (argc < 4) {
+        fprintf(stderr,
+                "Usage: c_client_example <sensor_hostname> <lidar_port> "
+                "<imu_port>\n");
+        return argc == 1 ? EXIT_SUCCESS : EXIT_FAILURE;
+    }
+
+    const char* hostname = argv[1];
+    int lidar_port = atoi(argv[2]);
+    int imu_port = atoi(argv[3]);
+    ouster_client_t* cli = ouster_client_create(hostname, lidar_port, imu_port);
+    if (!cli) {
+        fprintf(stderr, "Failed to create Ouster client for %s\n", hostname);
+        return EXIT_FAILURE;
+    }
+
+    if (ouster_client_fetch_and_parse_metadata(cli, 30) != 0) {
+        fprintf(stderr, "Failed to fetch/parse metadata\n");
+        ouster_client_destroy(cli);
+        return EXIT_FAILURE;
+    }
+
+    int w = 0, h = 0;
+    size_t lidar_sz = 0, imu_sz = 0;
+    ouster_client_get_frame_dimensions(cli, &w, &h);
+    ouster_client_get_packet_sizes(cli, &lidar_sz, &imu_sz);
+    printf(
+        "Connected: frame dimensions %dx%d, lidar packet size %zu, imu packet "
+        "size %zu\n",
+        w, h, lidar_sz, imu_sz);
+
+    /* Print a small snippet of metadata */
+    char meta_buf[512];
+    int meta_copied =
+        ouster_client_get_metadata(cli, meta_buf, sizeof(meta_buf));
+    printf("Metadata snippet (%d bytes copied):\n%.*s\n", meta_copied,
+           meta_copied, meta_buf);
+
+    /* Poll and read up to 5 lidar packets */
+    uint8_t* lidar_buf = (uint8_t*)malloc(lidar_sz);
+    if (!lidar_buf) {
+        fprintf(stderr, "Allocation failed\n");
+        ouster_client_destroy(cli);
+        return EXIT_FAILURE;
+    }
+
+    int received = 0;
+    while (received < 5) {
+        int st = ouster_client_poll(cli, 1);
+        if (st & OU_CLIENT_LIDAR_DATA) {
+            if (ouster_client_read_lidar_packet(cli, lidar_buf, lidar_sz)) {
+                printf("Got lidar packet %d/%d (first byte: %u)\n",
+                       received + 1, 5, (unsigned)lidar_buf[0]);
+                received++;
+            }
+        } else if (st & OU_CLIENT_ERROR) {
+            fprintf(stderr, "Client error during poll\n");
+            break;
+        } else if (st & OU_CLIENT_TIMEOUT) {
+            printf("Poll timeout; retrying...\n");
+        }
+    }
+
+    free(lidar_buf);
+    ouster_client_destroy(cli);
+    printf("Done.\n");
+    return EXIT_SUCCESS;
+}

--- a/examples/c_scan_source_example.c
+++ b/examples/c_scan_source_example.c
@@ -37,6 +37,15 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
+    ouster_xyz_lut_t* lut =
+        ouster_scan_source_create_xyz_lut(src, /*use_extrinsics=*/1);
+    if (!lut) {
+        fprintf(stderr, "Failed to create XYZ LUT\n");
+        free(xyz);
+        ouster_scan_source_destroy(src);
+        return EXIT_FAILURE;
+    }
+
     int scans_needed = 5;
     int scans_got = 0;
     while (scans_got < scans_needed) {
@@ -48,7 +57,7 @@ int main(int argc, char** argv) {
 
         // Convert to XYZ
         size_t n_points = 0;
-        if (ouster_lidar_scan_get_xyz(src, scan, xyz, max_points, &n_points,
+        if (ouster_lidar_scan_get_xyz(scan, lut, xyz, max_points, &n_points,
                                       /*filter_invalid=*/0) != 0) {
             fprintf(stderr, "Failed to convert scan to XYZ\n");
             ouster_lidar_scan_destroy(scan);
@@ -86,6 +95,7 @@ int main(int argc, char** argv) {
     }
 
     free(xyz);
+    ouster_xyz_lut_destroy(lut);
     ouster_scan_source_destroy(src);
     printf("Done.\n");
     return EXIT_SUCCESS;

--- a/examples/c_scan_source_example.c
+++ b/examples/c_scan_source_example.c
@@ -68,7 +68,7 @@ int main(int argc, char** argv) {
         uint32_t* range = (uint32_t*)malloc(max_points * sizeof(uint32_t));
         size_t range_count = 0;
         if (range && ouster_lidar_scan_get_field_u32(
-                         scan, "RANGE", range, max_points, &range_count) == 0) {
+                         scan, "RANGE", 0, range, max_points, &range_count) == 0) {
             printf("First RANGE values: ");
             for (size_t i = 0; i < (range_count < 8 ? range_count : 8); ++i)
                 printf("%u ", range[i]);

--- a/examples/c_scan_source_example.c
+++ b/examples/c_scan_source_example.c
@@ -1,0 +1,92 @@
+/*
+ * Pure C example using scan source wrapper to collect a few scans and output
+ * point clouds to CSV files.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ouster_c.h"
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: c_scan_source_example <sensor_hostname>\n");
+        return argc == 1 ? EXIT_SUCCESS : EXIT_FAILURE;
+    }
+    const char* hostname = argv[1];
+
+    ouster_scan_source_t* src = NULL;
+    if (ouster_scan_source_create(hostname, &src) != 0 || !src) {
+        fprintf(stderr, "Failed to create scan source\n");
+        return EXIT_FAILURE;
+    }
+
+    int w = 0, h = 0;
+    if (ouster_scan_source_frame_dimensions(src, &w, &h) != 0) {
+        fprintf(stderr, "Failed to get frame dimensions\n");
+        ouster_scan_source_destroy(src);
+        return EXIT_FAILURE;
+    }
+    printf("Frame dimensions: %dx%d\n", w, h);
+
+    size_t max_points = (size_t)w * (size_t)h;
+    float* xyz = (float*)malloc(max_points * 3 * sizeof(float));
+    if (!xyz) {
+        fprintf(stderr, "Allocation failure\n");
+        ouster_scan_source_destroy(src);
+        return EXIT_FAILURE;
+    }
+
+    int scans_needed = 5;
+    int scans_got = 0;
+    while (scans_got < scans_needed) {
+        ouster_lidar_scan_t* scan = ouster_scan_source_next_scan(src, 2);
+        if (!scan) {
+            printf("Timeout waiting for scan...\n");
+            continue;
+        }
+
+        // Convert to XYZ
+        size_t n_points = 0;
+        if (ouster_lidar_scan_get_xyz(src, scan, xyz, max_points, &n_points,
+                                      /*filter_invalid=*/0) != 0) {
+            fprintf(stderr, "Failed to convert scan to XYZ\n");
+            ouster_lidar_scan_destroy(scan);
+            break;
+        }
+
+        // Extract RANGE field as uint32 for optional inspection
+        uint32_t* range = (uint32_t*)malloc(max_points * sizeof(uint32_t));
+        size_t range_count = 0;
+        if (range && ouster_lidar_scan_get_field_u32(
+                         scan, "RANGE", range, max_points, &range_count) == 0) {
+            printf("First RANGE values: ");
+            for (size_t i = 0; i < (range_count < 8 ? range_count : 8); ++i)
+                printf("%u ", range[i]);
+            printf("...\n");
+        }
+        free(range);
+
+        char fname[64];
+        snprintf(fname, sizeof(fname), "c_cloud_%d.csv", scans_got);
+        FILE* f = fopen(fname, "w");
+        if (!f) {
+            fprintf(stderr, "Could not open output file %s\n", fname);
+            ouster_lidar_scan_destroy(scan);
+            break;
+        }
+        for (size_t i = 0; i < n_points; ++i) {
+            fprintf(f, "%f,%f,%f\n", xyz[3 * i], xyz[3 * i + 1],
+                    xyz[3 * i + 2]);
+        }
+        fclose(f);
+        printf("Wrote %s with %zu points\n", fname, n_points);
+        scans_got++;
+        ouster_lidar_scan_destroy(scan);
+    }
+
+    free(xyz);
+    ouster_scan_source_destroy(src);
+    printf("Done.\n");
+    return EXIT_SUCCESS;
+}

--- a/ouster_c/CMakeLists.txt
+++ b/ouster_c/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(ouster_c SHARED
     src/ouster_scan_source_c.cpp
 )
 
+target_compile_definitions(ouster_c PRIVATE OUSTER_C_BUILD)
+
 target_include_directories(ouster_c
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/ouster_c/CMakeLists.txt
+++ b/ouster_c/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(ouster_c_wrapper LANGUAGES C CXX)
+
+add_library(ouster_c SHARED
+    src/ouster_c.cpp
+    src/ouster_scan_source_c.cpp
+)
+
+target_include_directories(ouster_c
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+set_target_properties(ouster_c PROPERTIES
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED ON
+    POSITION_INDEPENDENT_CODE ON
+    OUTPUT_NAME ouster_c
+)
+
+target_link_libraries(ouster_c
+    PRIVATE
+        ouster_sensor
+        ouster_client
+)
+
+install(TARGETS ouster_c
+    EXPORT ouster-sdk-targets
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+install(FILES include/ouster_c.h DESTINATION include)

--- a/ouster_c/include/ouster_c.h
+++ b/ouster_c/include/ouster_c.h
@@ -119,15 +119,25 @@ void ouster_lidar_scan_get_dimensions(const ouster_lidar_scan_t* scan,
  * capacity insufficient, -3 invalid args.
  */
 int ouster_lidar_scan_get_field_u32(const ouster_lidar_scan_t* scan,
-                                    const char* field_name, uint32_t* out_buf,
-                                    size_t capacity, size_t* out_count);
+                                    const char* field_name, int destagger,
+                                    uint32_t* out_buf, size_t capacity,
+                                    size_t* out_count);
 
 /* Extract a channel field as uint16_t array.
  * Same return conventions as above.
  */
 int ouster_lidar_scan_get_field_u16(const ouster_lidar_scan_t* scan,
-                                    const char* field_name, uint16_t* out_buf,
-                                    size_t capacity, size_t* out_count);
+                                    const char* field_name, int destagger,
+                                    uint16_t* out_buf, size_t capacity,
+                                    size_t* out_count);
+
+/* Extract a channel field as uint8_t array.
+ * Same return conventions as above.
+ */
+int ouster_lidar_scan_get_field_u8(const ouster_lidar_scan_t* scan,
+                                   const char* field_name, int destagger,
+                                   uint8_t* out_buf, size_t capacity,
+                                   size_t* out_count);
 
 /* Convert scan to XYZ using scan source's lookup table.
  * xyz_out: float array length >= capacity_points * 3.
@@ -145,7 +155,8 @@ int ouster_lidar_scan_get_xyz(const ouster_lidar_scan_t* scan,
 
 /* Create an XYZ lookup table from a scan source. use_extrinsics != 0 to
  * include extrinsics in the LUT calculation. Returns NULL on error. */
-ouster_xyz_lut_t* ouster_scan_source_create_xyz_lut(const ouster_scan_source_t* source, int use_extrinsics);
+ouster_xyz_lut_t* ouster_scan_source_create_xyz_lut(const ouster_scan_source_t* source,
+                                                    int use_extrinsics);
 
 /* Destroy an XYZLut handle */
 void ouster_xyz_lut_destroy(ouster_xyz_lut_t* lut);

--- a/ouster_c/include/ouster_c.h
+++ b/ouster_c/include/ouster_c.h
@@ -1,0 +1,142 @@
+/**
+ * Minimal C wrapper for a subset of the Ouster SDK sensor client API.
+ *
+ * This header exposes an opaque handle and a small collection of functions
+ * sufficient to connect to a sensor, obtain metadata, derive packet sizes,
+ * poll for data readiness, and read raw lidar/imu packets.
+ *
+ * The wrapper purposely limits scope; for advanced batching and point cloud
+ * generation use the native C++ API.
+ */
+#ifndef OUSTER_C_WRAPPER_H
+#define OUSTER_C_WRAPPER_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque client handle */
+typedef struct ouster_client ouster_client_t;
+
+/* Mirror of client_state enum */
+typedef enum {
+    OU_CLIENT_TIMEOUT = 0,
+    OU_CLIENT_ERROR = 1,
+    OU_CLIENT_LIDAR_DATA = 2,
+    OU_CLIENT_IMU_DATA = 4,
+    OU_CLIENT_EXIT = 8
+} ouster_client_state_t;
+
+/* Create a client (short-form init that does not push configuration). */
+ouster_client_t* ouster_client_create(const char* hostname, int lidar_port,
+                                      int imu_port);
+
+/* Destroy and free all resources. */
+void ouster_client_destroy(ouster_client_t* client);
+
+/* Poll for up to timeout_sec seconds; returns bitmask of ouster_client_state_t.
+ */
+int ouster_client_poll(ouster_client_t* client, int timeout_sec);
+
+/* Fetch metadata from the sensor. Returns length copied into buffer (truncates
+ * if capacity insufficient). */
+int ouster_client_get_metadata(ouster_client_t* client, char* buffer,
+                               size_t capacity);
+
+/* Fetch and parse metadata, caching sensor_info / packet_format internally.
+ * Returns 0 on success, non-zero on failure. */
+int ouster_client_fetch_and_parse_metadata(ouster_client_t* client,
+                                           int timeout_sec);
+
+/* After parsing metadata, query frame dimensions. Returns 0 on success. */
+int ouster_client_get_frame_dimensions(const ouster_client_t* client,
+                                       int* width, int* height);
+
+/* After parsing metadata, query packet sizes. Returns 0 on success. */
+int ouster_client_get_packet_sizes(const ouster_client_t* client,
+                                   size_t* lidar_packet_size,
+                                   size_t* imu_packet_size);
+
+/* Read a lidar packet into user-provided buffer (must be >= lidar_packet_size).
+ * Returns 1 if packet read, 0 otherwise. */
+int ouster_client_read_lidar_packet(ouster_client_t* client, uint8_t* buf,
+                                    size_t buf_size);
+
+/* Read an imu packet into user-provided buffer (must be >= imu_packet_size).
+ * Returns 1 if packet read, 0 otherwise. */
+int ouster_client_read_imu_packet(ouster_client_t* client, uint8_t* buf,
+                                  size_t buf_size);
+
+/* Access chosen UDP ports. */
+int ouster_client_get_lidar_port(const ouster_client_t* client);
+int ouster_client_get_imu_port(const ouster_client_t* client);
+
+/* ================= Scan Source High-Level API ================= */
+
+typedef struct ouster_scan_source ouster_scan_source_t;
+typedef struct ouster_lidar_scan ouster_lidar_scan_t;
+
+/* Create a scan source for a single sensor hostname (auto UDP dest). Returns 0
+ * on success. */
+int ouster_scan_source_create(const char* hostname,
+                              ouster_scan_source_t** out_source);
+
+/* Destroy scan source */
+void ouster_scan_source_destroy(ouster_scan_source_t* source);
+
+/* Get frame dimensions (width = columns_per_frame, height = pixels_per_column).
+ */
+int ouster_scan_source_frame_dimensions(const ouster_scan_source_t* source,
+                                        int* width, int* height);
+
+/* Get metadata JSON snippet (like client). Returns bytes copied (or full length
+ * if buffer null). */
+int ouster_scan_source_get_metadata(ouster_scan_source_t* source, char* buffer,
+                                    size_t capacity);
+
+/* Blocking fetch of next scan up to timeout_sec seconds.
+ * Returns pointer to newly allocated scan handle on success.
+ * Returns NULL on timeout or error.
+ */
+ouster_lidar_scan_t* ouster_scan_source_next_scan(ouster_scan_source_t* source,
+                                                  int timeout_sec);
+
+/* Destroy a scan handle returned by ouster_scan_source_next_scan */
+void ouster_lidar_scan_destroy(ouster_lidar_scan_t* scan);
+
+/* Extract a channel field as uint32_t array.
+ * out_buf capacity (in elements) must be >= number of pixels (w*h).
+ * Writes count to out_count. Returns 0 on success, -1 unknown field, -2
+ * capacity insufficient, -3 invalid args.
+ */
+int ouster_lidar_scan_get_field_u32(const ouster_lidar_scan_t* scan,
+                                    const char* field_name, uint32_t* out_buf,
+                                    size_t capacity, size_t* out_count);
+
+/* Extract a channel field as uint16_t array.
+ * Same return conventions as above.
+ */
+int ouster_lidar_scan_get_field_u16(const ouster_lidar_scan_t* scan,
+                                    const char* field_name, uint16_t* out_buf,
+                                    size_t capacity, size_t* out_count);
+
+/* Convert scan to XYZ using scan source's lookup table.
+ * xyz_out: float array length >= capacity_points * 3.
+ * If filter_invalid != 0, skips points with all-zero coordinates.
+ * Writes number of points stored to out_points.
+ * Returns 0 on success, -2 insufficient capacity (when not filtering), -3 bad
+ * args.
+ */
+int ouster_lidar_scan_get_xyz(const ouster_scan_source_t* source,
+                              const ouster_lidar_scan_t* scan, float* xyz_out,
+                              size_t capacity_points, size_t* out_points,
+                              int filter_invalid);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* OUSTER_C_WRAPPER_H */

--- a/ouster_c/include/ouster_c.h
+++ b/ouster_c/include/ouster_c.h
@@ -14,6 +14,21 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/* Export macro for building shared library with proper symbol visibility */
+#if defined(_WIN32) || defined(__CYGWIN__)
+    #ifdef OUSTER_C_BUILD
+        #define OUSTER_C_API __declspec(dllexport)
+    #else
+        #define OUSTER_C_API __declspec(dllimport)
+    #endif
+#else
+    #if __GNUC__ >= 4
+        #define OUSTER_C_API __attribute__((visibility("default")))
+    #else
+        #define OUSTER_C_API
+    #endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -31,48 +46,48 @@ typedef enum {
 } ouster_client_state_t;
 
 /* Create a client (short-form init that does not push configuration). */
-ouster_client_t* ouster_client_create(const char* hostname, int lidar_port,
-                                      int imu_port);
+OUSTER_C_API ouster_client_t* ouster_client_create(const char* hostname, int lidar_port,
+                                                   int imu_port);
 
 /* Destroy and free all resources. */
-void ouster_client_destroy(ouster_client_t* client);
+OUSTER_C_API void ouster_client_destroy(ouster_client_t* client);
 
 /* Poll for up to timeout_sec seconds; returns bitmask of ouster_client_state_t.
  */
-int ouster_client_poll(ouster_client_t* client, int timeout_sec);
+OUSTER_C_API int ouster_client_poll(ouster_client_t* client, int timeout_sec);
 
 /* Fetch metadata from the sensor. Returns length copied into buffer (truncates
  * if capacity insufficient). */
-int ouster_client_get_metadata(ouster_client_t* client, char* buffer,
-                               size_t capacity);
+OUSTER_C_API int ouster_client_get_metadata(ouster_client_t* client, char* buffer,
+                                            size_t capacity);
 
 /* Fetch and parse metadata, caching sensor_info / packet_format internally.
  * Returns 0 on success, non-zero on failure. */
-int ouster_client_fetch_and_parse_metadata(ouster_client_t* client,
-                                           int timeout_sec);
+OUSTER_C_API int ouster_client_fetch_and_parse_metadata(ouster_client_t* client,
+                                                        int timeout_sec);
 
 /* After parsing metadata, query frame dimensions. Returns 0 on success. */
-int ouster_client_get_frame_dimensions(const ouster_client_t* client,
-                                       int* width, int* height);
+OUSTER_C_API int ouster_client_get_frame_dimensions(const ouster_client_t* client,
+                                                    int* width, int* height);
 
 /* After parsing metadata, query packet sizes. Returns 0 on success. */
-int ouster_client_get_packet_sizes(const ouster_client_t* client,
-                                   size_t* lidar_packet_size,
-                                   size_t* imu_packet_size);
+OUSTER_C_API int ouster_client_get_packet_sizes(const ouster_client_t* client,
+                                                size_t* lidar_packet_size,
+                                                size_t* imu_packet_size);
 
 /* Read a lidar packet into user-provided buffer (must be >= lidar_packet_size).
  * Returns 1 if packet read, 0 otherwise. */
-int ouster_client_read_lidar_packet(ouster_client_t* client, uint8_t* buf,
-                                    size_t buf_size);
+OUSTER_C_API int ouster_client_read_lidar_packet(ouster_client_t* client, uint8_t* buf,
+                                                 size_t buf_size);
 
 /* Read an imu packet into user-provided buffer (must be >= imu_packet_size).
  * Returns 1 if packet read, 0 otherwise. */
-int ouster_client_read_imu_packet(ouster_client_t* client, uint8_t* buf,
-                                  size_t buf_size);
+OUSTER_C_API int ouster_client_read_imu_packet(ouster_client_t* client, uint8_t* buf,
+                                               size_t buf_size);
 
 /* Access chosen UDP ports. */
-int ouster_client_get_lidar_port(const ouster_client_t* client);
-int ouster_client_get_imu_port(const ouster_client_t* client);
+OUSTER_C_API int ouster_client_get_lidar_port(const ouster_client_t* client);
+OUSTER_C_API int ouster_client_get_imu_port(const ouster_client_t* client);
 
 /* ================= Scan Source High-Level API ================= */
 
@@ -82,62 +97,62 @@ typedef struct ouster_xyz_lut ouster_xyz_lut_t;
 
 /* Create a scan source for a single sensor hostname (auto UDP dest). Returns 0
  * on success. */
-int ouster_scan_source_create(const char* hostname,
-                              ouster_scan_source_t** out_source);
+OUSTER_C_API int ouster_scan_source_create(const char* hostname,
+                                           ouster_scan_source_t** out_source);
 
 /* Destroy scan source */
-void ouster_scan_source_destroy(ouster_scan_source_t* source);
+OUSTER_C_API void ouster_scan_source_destroy(ouster_scan_source_t* source);
 
 /* Get frame dimensions (width = columns_per_frame, height = pixels_per_column).
  */
-int ouster_scan_source_frame_dimensions(const ouster_scan_source_t* source,
-                                        int* width, int* height);
+OUSTER_C_API int ouster_scan_source_frame_dimensions(const ouster_scan_source_t* source,
+                                                     int* width, int* height);
 
 /* Get metadata JSON snippet (like client). Returns bytes copied (or full length
  * if buffer null). */
-int ouster_scan_source_get_metadata(ouster_scan_source_t* source, char* buffer,
-                                    size_t capacity);
+OUSTER_C_API int ouster_scan_source_get_metadata(ouster_scan_source_t* source, char* buffer,
+                                                 size_t capacity);
 
 /* Blocking fetch of next scan up to timeout_sec seconds.
  * Returns pointer to newly allocated scan handle on success.
  * Returns NULL on timeout or error.
  */
-ouster_lidar_scan_t* ouster_scan_source_next_scan(ouster_scan_source_t* source,
-                                                  int timeout_sec);
+OUSTER_C_API ouster_lidar_scan_t* ouster_scan_source_next_scan(ouster_scan_source_t* source,
+                                                               int timeout_sec);
 
 /* Destroy a scan handle returned by ouster_scan_source_next_scan */
-void ouster_lidar_scan_destroy(ouster_lidar_scan_t* scan);
+OUSTER_C_API void ouster_lidar_scan_destroy(ouster_lidar_scan_t* scan);
 
 /* Get scan dimensions (width = columns_per_frame, height = pixels_per_column).
  */
-void ouster_lidar_scan_get_dimensions(const ouster_lidar_scan_t* scan,
-                                      int* width, int* height);
+OUSTER_C_API void ouster_lidar_scan_get_dimensions(const ouster_lidar_scan_t* scan,
+                                                   int* width, int* height);
 
 /* Extract a channel field as uint32_t array.
  * out_buf capacity (in elements) must be >= number of pixels (w*h).
  * Writes count to out_count. Returns 0 on success, -1 unknown field, -2
  * capacity insufficient, -3 invalid args.
  */
-int ouster_lidar_scan_get_field_u32(const ouster_lidar_scan_t* scan,
-                                    const char* field_name, int destagger,
-                                    uint32_t* out_buf, size_t capacity,
-                                    size_t* out_count);
+OUSTER_C_API int ouster_lidar_scan_get_field_u32(const ouster_lidar_scan_t* scan,
+                                                 const char* field_name, int destagger,
+                                                 uint32_t* out_buf, size_t capacity,
+                                                 size_t* out_count);
 
 /* Extract a channel field as uint16_t array.
  * Same return conventions as above.
  */
-int ouster_lidar_scan_get_field_u16(const ouster_lidar_scan_t* scan,
-                                    const char* field_name, int destagger,
-                                    uint16_t* out_buf, size_t capacity,
-                                    size_t* out_count);
+OUSTER_C_API int ouster_lidar_scan_get_field_u16(const ouster_lidar_scan_t* scan,
+                                                 const char* field_name, int destagger,
+                                                 uint16_t* out_buf, size_t capacity,
+                                                 size_t* out_count);
 
 /* Extract a channel field as uint8_t array.
  * Same return conventions as above.
  */
-int ouster_lidar_scan_get_field_u8(const ouster_lidar_scan_t* scan,
-                                   const char* field_name, int destagger,
-                                   uint8_t* out_buf, size_t capacity,
-                                   size_t* out_count);
+OUSTER_C_API int ouster_lidar_scan_get_field_u8(const ouster_lidar_scan_t* scan,
+                                                const char* field_name, int destagger,
+                                                uint8_t* out_buf, size_t capacity,
+                                                size_t* out_count);
 
 /* Convert scan to XYZ using scan source's lookup table.
  * xyz_out: float array length >= capacity_points * 3.
@@ -146,20 +161,20 @@ int ouster_lidar_scan_get_field_u8(const ouster_lidar_scan_t* scan,
  * Returns 0 on success, -2 insufficient capacity (when not filtering), -3 bad
  * args.
  */
-int ouster_lidar_scan_get_xyz(const ouster_lidar_scan_t* scan,
-                              const ouster_xyz_lut_t* xyz_lut, float* xyz_out,
-                              size_t capacity_points, size_t* out_points,
-                              int filter_invalid);
+OUSTER_C_API int ouster_lidar_scan_get_xyz(const ouster_lidar_scan_t* scan,
+                                           const ouster_xyz_lut_t* xyz_lut, float* xyz_out,
+                                           size_t capacity_points, size_t* out_points,
+                                           int filter_invalid);
 
 /* ================= Explicit XYZLut Management ================= */
 
 /* Create an XYZ lookup table from a scan source. use_extrinsics != 0 to
  * include extrinsics in the LUT calculation. Returns NULL on error. */
-ouster_xyz_lut_t* ouster_scan_source_create_xyz_lut(const ouster_scan_source_t* source,
-                                                    int use_extrinsics);
+OUSTER_C_API ouster_xyz_lut_t* ouster_scan_source_create_xyz_lut(const ouster_scan_source_t* source,
+                                                                 int use_extrinsics);
 
 /* Destroy an XYZLut handle */
-void ouster_xyz_lut_destroy(ouster_xyz_lut_t* lut);
+OUSTER_C_API void ouster_xyz_lut_destroy(ouster_xyz_lut_t* lut);
 
 
 #ifdef __cplusplus

--- a/ouster_c/include/ouster_c.h
+++ b/ouster_c/include/ouster_c.h
@@ -78,6 +78,7 @@ int ouster_client_get_imu_port(const ouster_client_t* client);
 
 typedef struct ouster_scan_source ouster_scan_source_t;
 typedef struct ouster_lidar_scan ouster_lidar_scan_t;
+typedef struct ouster_xyz_lut ouster_xyz_lut_t;
 
 /* Create a scan source for a single sensor hostname (auto UDP dest). Returns 0
  * on success. */
@@ -107,6 +108,11 @@ ouster_lidar_scan_t* ouster_scan_source_next_scan(ouster_scan_source_t* source,
 /* Destroy a scan handle returned by ouster_scan_source_next_scan */
 void ouster_lidar_scan_destroy(ouster_lidar_scan_t* scan);
 
+/* Get scan dimensions (width = columns_per_frame, height = pixels_per_column).
+ */
+void ouster_lidar_scan_get_dimensions(const ouster_lidar_scan_t* scan,
+                                      int* width, int* height);
+
 /* Extract a channel field as uint32_t array.
  * out_buf capacity (in elements) must be >= number of pixels (w*h).
  * Writes count to out_count. Returns 0 on success, -1 unknown field, -2
@@ -130,10 +136,20 @@ int ouster_lidar_scan_get_field_u16(const ouster_lidar_scan_t* scan,
  * Returns 0 on success, -2 insufficient capacity (when not filtering), -3 bad
  * args.
  */
-int ouster_lidar_scan_get_xyz(const ouster_scan_source_t* source,
-                              const ouster_lidar_scan_t* scan, float* xyz_out,
+int ouster_lidar_scan_get_xyz(const ouster_lidar_scan_t* scan,
+                              const ouster_xyz_lut_t* xyz_lut, float* xyz_out,
                               size_t capacity_points, size_t* out_points,
                               int filter_invalid);
+
+/* ================= Explicit XYZLut Management ================= */
+
+/* Create an XYZ lookup table from a scan source. use_extrinsics != 0 to
+ * include extrinsics in the LUT calculation. Returns NULL on error. */
+ouster_xyz_lut_t* ouster_scan_source_create_xyz_lut(const ouster_scan_source_t* source, int use_extrinsics);
+
+/* Destroy an XYZLut handle */
+void ouster_xyz_lut_destroy(ouster_xyz_lut_t* lut);
+
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/ouster_c/include/ouster_c.h
+++ b/ouster_c/include/ouster_c.h
@@ -1,12 +1,11 @@
 /**
- * Minimal C wrapper for a subset of the Ouster SDK sensor client API.
+ * C wrapper for the Ouster SDK (ouster_client + ouster_sensor).
  *
- * This header exposes an opaque handle and a small collection of functions
- * sufficient to connect to a sensor, obtain metadata, derive packet sizes,
- * poll for data readiness, and read raw lidar/imu packets.
+ * Functions map to the public C++ API in ouster_client/include/ouster/ and
+ * ouster_sensor/include/ouster/. Opaque handles mirror C++ objects; numeric
+ * enums match the underlying C++ enumerator values unless noted.
  *
- * The wrapper purposely limits scope; for advanced batching and point cloud
- * generation use the native C++ API.
+ * Not wrapped here: ouster_viz, ouster_pcap, ouster_osf, and third-party code.
  */
 #ifndef OUSTER_C_WRAPPER_H
 #define OUSTER_C_WRAPPER_H
@@ -123,10 +122,29 @@ OUSTER_C_API ouster_lidar_scan_t* ouster_scan_source_next_scan(ouster_scan_sourc
 /* Destroy a scan handle returned by ouster_scan_source_next_scan */
 OUSTER_C_API void ouster_lidar_scan_destroy(ouster_lidar_scan_t* scan);
 
+/****************** SCAN ACCESSOR METHODS ******************/
+
 /* Get scan dimensions (width = columns_per_frame, height = pixels_per_column).
  */
 OUSTER_C_API void ouster_lidar_scan_get_dimensions(const ouster_lidar_scan_t* scan,
                                                    int* width, int* height);
+
+OUSTER_C_API size_t ouster_lidar_scan_columns_per_packet(const ouster_lidar_scan_t* scan);
+
+OUSTER_C_API int64_t ouster_lidar_scan_frame_id(const ouster_lidar_scan_t* scan);
+
+OUSTER_C_API uint64_t ouster_lidar_scan_frame_status(const ouster_lidar_scan_t* scan);
+
+/** sensor::ShotLimitingStatus numeric values */
+OUSTER_C_API int ouster_lidar_scan_shot_limiting_status(const ouster_lidar_scan_t* scan);
+
+/** sensor::ThermalShutdownStatus numeric values */
+OUSTER_C_API int ouster_lidar_scan_thermal_shutdown_status(const ouster_lidar_scan_t* scan);
+
+/** LidarScan::complete() — -1 if sensor_info missing, else 0/1 */
+OUSTER_C_API int ouster_lidar_scan_complete(const ouster_lidar_scan_t* scan);
+// TODO: add the 2nd version of LidarScan::complete
+
 
 /* Extract a channel field as uint32_t array.
  * out_buf capacity (in elements) must be >= number of pixels (w*h).

--- a/ouster_c/src/ouster_c.cpp
+++ b/ouster_c/src/ouster_c.cpp
@@ -1,0 +1,168 @@
+// C wrapper implementation
+#include "ouster_c.h"
+
+#include <chrono>
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <new>
+#include <string>
+#include <thread>
+
+#include "ouster/cartesian.h"
+#include "ouster/client.h"  // init_client, poll_client, read_*_packet, get_metadata
+#include "ouster/field.h"
+#include "ouster/lidar_scan.h"
+#include "ouster/metadata.h"  // parse_and_validate_metadata
+#include "ouster/sensor_scan_source.h"
+#include "ouster/types.h"  // sensor_info, packet_format
+
+struct ouster_client {
+    std::shared_ptr<ouster::sensor::client> cli;        // underlying C++ client
+    std::string metadata;                               // cached metadata json
+    std::unique_ptr<ouster::sensor::sensor_info> info;  // parsed info
+    std::unique_ptr<ouster::sensor::packet_format> pf;  // packet format
+};
+
+static int set_error_and_return(int code) { return code; }
+
+extern "C" {
+
+ouster_client_t* ouster_client_create(const char* hostname, int lidar_port,
+                                      int imu_port) {
+    if (!hostname) return nullptr;
+    try {
+        auto cpp_cli = ouster::sensor::init_client(std::string(hostname),
+                                                   lidar_port, imu_port);
+        if (!cpp_cli) return nullptr;
+        ouster_client_t* handle = new (std::nothrow) ouster_client();
+        if (!handle) return nullptr;
+        handle->cli = cpp_cli;
+        return handle;
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void ouster_client_destroy(ouster_client_t* client) {
+    if (!client) return;
+    client->pf.reset();
+    client->info.reset();
+    client->cli.reset();
+    delete client;
+}
+
+int ouster_client_poll(ouster_client_t* client, int timeout_sec) {
+    if (!client || !client->cli) return OU_CLIENT_ERROR;
+    try {
+        auto state = ouster::sensor::poll_client(*client->cli, timeout_sec);
+        return static_cast<int>(state);
+    } catch (...) {
+        return OU_CLIENT_ERROR;
+    }
+}
+
+int ouster_client_get_metadata(ouster_client_t* client, char* buffer,
+                               size_t capacity) {
+    if (!client || !client->cli) return -1;
+    try {
+        if (client->metadata.empty()) {
+            client->metadata = ouster::sensor::get_metadata(*client->cli);
+        }
+        if (!buffer || capacity == 0) return (int)client->metadata.size();
+        size_t to_copy = client->metadata.size() < capacity
+                             ? client->metadata.size()
+                             : capacity - 1;  // reserve NUL
+        std::memcpy(buffer, client->metadata.data(), to_copy);
+        buffer[to_copy] = '\0';
+        return (int)to_copy;
+    } catch (...) {
+        return -1;
+    }
+}
+
+int ouster_client_fetch_and_parse_metadata(ouster_client_t* client,
+                                           int timeout_sec) {
+    if (!client || !client->cli) return set_error_and_return(-1);
+    try {
+        client->metadata =
+            ouster::sensor::get_metadata(*client->cli, timeout_sec);
+        ouster::ValidatorIssues issues;
+        nonstd::optional<ouster::sensor::sensor_info> si_opt;
+        bool ok = ouster::parse_and_validate_metadata(client->metadata, si_opt,
+                                                      issues);
+        if (!ok || !si_opt.has_value()) {
+            return set_error_and_return(-2);
+        }
+        client->info =
+            std::make_unique<ouster::sensor::sensor_info>(si_opt.value());
+        client->pf =
+            std::make_unique<ouster::sensor::packet_format>(*client->info);
+        return 0;
+    } catch (...) {
+        return set_error_and_return(-3);
+    }
+}
+
+int ouster_client_get_frame_dimensions(const ouster_client_t* client,
+                                       int* width, int* height) {
+    if (!client || !client->info) return -1;
+    if (width) *width = static_cast<int>(client->info->w());
+    if (height) *height = static_cast<int>(client->info->h());
+    return 0;
+}
+
+int ouster_client_get_packet_sizes(const ouster_client_t* client,
+                                   size_t* lidar_packet_size,
+                                   size_t* imu_packet_size) {
+    if (!client || !client->pf) return -1;
+    if (lidar_packet_size) *lidar_packet_size = client->pf->lidar_packet_size;
+    if (imu_packet_size) *imu_packet_size = client->pf->imu_packet_size;
+    return 0;
+}
+
+int ouster_client_read_lidar_packet(ouster_client_t* client, uint8_t* buf,
+                                    size_t buf_size) {
+    if (!client || !client->cli || !client->pf || !buf) return 0;
+    size_t needed = client->pf->lidar_packet_size;
+    if (buf_size < needed) return 0;
+    try {
+        bool ok = ouster::sensor::read_lidar_packet(*client->cli, buf, needed);
+        return ok ? 1 : 0;
+    } catch (...) {
+        return 0;
+    }
+}
+
+int ouster_client_read_imu_packet(ouster_client_t* client, uint8_t* buf,
+                                  size_t buf_size) {
+    if (!client || !client->cli || !client->pf || !buf) return 0;
+    size_t needed = client->pf->imu_packet_size;
+    if (buf_size < needed) return 0;
+    try {
+        bool ok = ouster::sensor::read_imu_packet(*client->cli, buf, needed);
+        return ok ? 1 : 0;
+    } catch (...) {
+        return 0;
+    }
+}
+
+int ouster_client_get_lidar_port(const ouster_client_t* client) {
+    if (!client || !client->cli) return -1;
+    try {
+        return ouster::sensor::get_lidar_port(*client->cli);
+    } catch (...) {
+        return -1;
+    }
+}
+
+int ouster_client_get_imu_port(const ouster_client_t* client) {
+    if (!client || !client->cli) return -1;
+    try {
+        return ouster::sensor::get_imu_port(*client->cli);
+    } catch (...) {
+        return -1;
+    }
+}
+
+}  // extern "C"

--- a/ouster_c/src/ouster_scan_source_c.cpp
+++ b/ouster_c/src/ouster_scan_source_c.cpp
@@ -1,0 +1,157 @@
+// C scan source wrapper implementation
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "ouster/cartesian.h"           // cartesian, XYZLut, make_xyz_lut
+#include "ouster/sensor_scan_source.h"  // SensorScanSource
+#include "ouster/types.h"               // sensor_info
+#include "ouster_c.h"
+
+struct ouster_scan_source {
+    std::unique_ptr<ouster::sensor::SensorScanSource> source;
+    std::vector<std::shared_ptr<ouster::sensor::sensor_info>>
+        infos;                         // cached infos
+    std::vector<ouster::XYZLut> luts;  // lookup tables
+};
+
+struct ouster_lidar_scan {
+    std::unique_ptr<ouster::LidarScan> ls;
+};
+
+extern "C" {
+
+/* ================= Scan Source Implementation ================= */
+
+int ouster_scan_source_create(const char* hostname,
+                              ouster_scan_source_t** out_source) {
+    if (!hostname || !out_source) return -1;
+    try {
+        std::vector<ouster::sensor::Sensor> sensors;
+        ouster::sensor::sensor_config cfg;  // default
+        cfg.udp_dest = "@auto";             // auto-detect
+        sensors.emplace_back(std::string(hostname), cfg);
+
+        auto src_ptr = std::make_unique<ouster_scan_source>();
+        src_ptr->source =
+            std::make_unique<ouster::sensor::SensorScanSource>(sensors);
+        src_ptr->infos = src_ptr->source->sensor_info();
+        for (auto& si : src_ptr->infos) {
+            src_ptr->luts.push_back(ouster::make_xyz_lut(*si, true));
+        }
+        *out_source = src_ptr.release();
+        return 0;
+    } catch (...) {
+        return -2;
+    }
+}
+
+void ouster_scan_source_destroy(ouster_scan_source_t* source) {
+    if (!source) return;
+    source->source.reset();
+    delete source;
+}
+
+int ouster_scan_source_frame_dimensions(const ouster_scan_source_t* source,
+                                        int* width, int* height) {
+    if (!source || source->infos.empty()) return -1;
+    auto& si = *source->infos[0];
+    if (width) *width = (int)si.format.columns_per_frame;
+    if (height) *height = (int)si.format.pixels_per_column;
+    return 0;
+}
+
+int ouster_scan_source_get_metadata(ouster_scan_source_t* source, char* buffer,
+                                    size_t capacity) {
+    if (!source) return -1;
+    const std::string& md = source->infos[0]->to_json_string();
+    if (!buffer || capacity == 0) return (int)md.size();
+    size_t to_copy = md.size() < capacity ? md.size() : capacity - 1;
+    std::memcpy(buffer, md.data(), to_copy);
+    buffer[to_copy] = '\0';
+    return (int)to_copy;
+}
+
+/* ================= LidarScan Implementation ================= */
+
+ouster_lidar_scan_t* ouster_scan_source_next_scan(ouster_scan_source_t* source,
+                                                  int timeout_sec) {
+    if (!source || !source->source) return nullptr;
+    auto start = std::chrono::steady_clock::now();
+    while (true) {
+        auto result = source->source->get_scan();
+        if (result.second) {
+            ouster_lidar_scan_t* scan_handle =
+                new (std::nothrow) ouster_lidar_scan();
+            if (!scan_handle) return nullptr;
+            scan_handle->ls = std::move(result.second);
+            return scan_handle;
+        }
+        if (timeout_sec >= 0) {
+            auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                               std::chrono::steady_clock::now() - start)
+                               .count();
+            if (elapsed >= timeout_sec) return nullptr;  // timeout
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+}
+
+void ouster_lidar_scan_destroy(ouster_lidar_scan_t* scan) {
+    if (!scan) return;
+    scan->ls.reset();
+    delete scan;
+}
+
+int ouster_lidar_scan_get_field_u32(const ouster_lidar_scan_t* scan,
+                                    const char* field_name, uint32_t* out_buf,
+                                    size_t capacity, size_t* out_count) {
+    if (!scan || !scan->ls || !field_name || !out_buf) return -3;
+    if (!scan->ls->has_field(field_name)) return -1;
+    auto arr = scan->ls->field<uint32_t>(field_name);
+    size_t n = (size_t)arr.size();
+    if (capacity < n) return -2;
+    std::memcpy(out_buf, arr.data(), n * sizeof(uint32_t));
+    if (out_count) *out_count = n;
+    return 0;
+}
+
+int ouster_lidar_scan_get_field_u16(const ouster_lidar_scan_t* scan,
+                                    const char* field_name, uint16_t* out_buf,
+                                    size_t capacity, size_t* out_count) {
+    if (!scan || !scan->ls || !field_name || !out_buf) return -3;
+    if (!scan->ls->has_field(field_name)) return -1;
+    auto arr = scan->ls->field<uint16_t>(field_name);
+    size_t n = (size_t)arr.size();
+    if (capacity < n) return -2;
+    std::memcpy(out_buf, arr.data(), n * sizeof(uint16_t));
+    if (out_count) *out_count = n;
+    return 0;
+}
+
+int ouster_lidar_scan_get_xyz(const ouster_scan_source_t* source,
+                              const ouster_lidar_scan_t* scan, float* xyz_out,
+                              size_t capacity_points, size_t* out_points,
+                              int filter_invalid) {
+    if (!source || !scan || !scan->ls || !xyz_out) return -3;
+    auto cloud = ouster::cartesian(*scan->ls, source->luts[0]);
+    size_t total = (size_t)cloud.rows();
+    size_t written = 0;
+    if (!filter_invalid && capacity_points < total) return -2;
+    for (int i = 0; i < cloud.rows(); ++i) {
+        auto xyz = cloud.row(i);
+        bool is_zero = xyz.isApproxToConstant(0.0);
+        if (filter_invalid && is_zero) continue;
+        if (written >= capacity_points)
+            break;  // stop if capacity filled when filtering
+        xyz_out[3 * written + 0] = static_cast<float>(xyz(0));
+        xyz_out[3 * written + 1] = static_cast<float>(xyz(1));
+        xyz_out[3 * written + 2] = static_cast<float>(xyz(2));
+        written++;
+    }
+    if (out_points) *out_points = written;
+    return 0;
+}
+
+}  // extern "C"

--- a/ouster_c/src/ouster_scan_source_c.cpp
+++ b/ouster_c/src/ouster_scan_source_c.cpp
@@ -114,27 +114,55 @@ void ouster_lidar_scan_get_dimensions(const ouster_lidar_scan_t* scan,
 }
 
 int ouster_lidar_scan_get_field_u32(const ouster_lidar_scan_t* scan,
-                                    const char* field_name, uint32_t* out_buf,
-                                    size_t capacity, size_t* out_count) {
+                                    const char* field_name, int destagger,
+                                    uint32_t* out_buf, size_t capacity,
+                                    size_t* out_count) {
     if (!scan || !scan->ls || !field_name || !out_buf) return -3;
     if (!scan->ls->has_field(field_name)) return -1;
-    auto arr = scan->ls->field<uint32_t>(field_name);
-    size_t n = (size_t)arr.size();
+    Eigen::Ref<ouster::img_t<uint32_t>> img = scan->ls->field<uint32_t>(field_name);
+    if (destagger) {
+        img = ouster::destagger<uint32_t>(
+            img, scan->ls->sensor_info->format.pixel_shift_by_row, false);
+    }
+    size_t n = (size_t)img.size();
     if (capacity < n) return -2;
-    std::memcpy(out_buf, arr.data(), n * sizeof(uint32_t));
+    std::memcpy(out_buf, img.data(), n * sizeof(uint32_t));
     if (out_count) *out_count = n;
     return 0;
 }
 
 int ouster_lidar_scan_get_field_u16(const ouster_lidar_scan_t* scan,
-                                    const char* field_name, uint16_t* out_buf,
-                                    size_t capacity, size_t* out_count) {
+                                    const char* field_name, int destagger,
+                                    uint16_t* out_buf, size_t capacity,
+                                    size_t* out_count) {
     if (!scan || !scan->ls || !field_name || !out_buf) return -3;
     if (!scan->ls->has_field(field_name)) return -1;
-    auto arr = scan->ls->field<uint16_t>(field_name);
-    size_t n = (size_t)arr.size();
+    Eigen::Ref<ouster::img_t<uint16_t>> img = scan->ls->field<uint16_t>(field_name);
+    if (destagger) {
+        img = ouster::destagger<uint16_t>(
+            img, scan->ls->sensor_info->format.pixel_shift_by_row, false);
+    }
+    size_t n = (size_t)img.size();
     if (capacity < n) return -2;
-    std::memcpy(out_buf, arr.data(), n * sizeof(uint16_t));
+    std::memcpy(out_buf, img.data(), n * sizeof(uint16_t));
+    if (out_count) *out_count = n;
+    return 0;
+}
+
+int ouster_lidar_scan_get_field_u8(const ouster_lidar_scan_t* scan,
+                                   const char* field_name, int destagger,
+                                   uint8_t* out_buf, size_t capacity,
+                                   size_t* out_count) {
+    if (!scan || !scan->ls || !field_name || !out_buf) return -3;
+    if (!scan->ls->has_field(field_name)) return -1;
+    Eigen::Ref<ouster::img_t<uint8_t>> img = scan->ls->field<uint8_t>(field_name);
+    if (destagger) {
+        img = ouster::destagger<uint8_t>(
+            img, scan->ls->sensor_info->format.pixel_shift_by_row, false);
+    }
+    size_t n = (size_t)img.size();
+    if (capacity < n) return -2;
+    std::memcpy(out_buf, img.data(), n * sizeof(uint8_t));
     if (out_count) *out_count = n;
     return 0;
 }

--- a/ouster_c/src/ouster_scan_source_c.cpp
+++ b/ouster_c/src/ouster_scan_source_c.cpp
@@ -113,9 +113,39 @@ void ouster_lidar_scan_get_dimensions(const ouster_lidar_scan_t* scan,
     if (height) *height = static_cast<int>(scan->ls->h);
 }
 
-int ouster_lidar_scan_get_field_u32(const ouster_lidar_scan_t* scan,
-                                    const char* field_name, int destagger,
-                                    uint32_t* out_buf, size_t capacity,
+size_t ouster_lidar_scan_columns_per_packet(const ouster_lidar_scan_t* scan) {
+    if (!scan || !scan->ls) return 0;
+    return scan->ls->columns_per_packet_;
+}
+
+int64_t ouster_lidar_scan_frame_id(const ouster_lidar_scan_t* scan) {
+    if (!scan || !scan->ls) return -1;
+    return scan->ls->frame_id;
+}
+
+uint64_t ouster_lidar_scan_frame_status(const ouster_lidar_scan_t* scan) {
+    if (!scan || !scan->ls) return 0;
+    return scan->ls->frame_status;
+}
+
+int ouster_lidar_scan_shot_limiting_status(const ouster_lidar_scan_t* scan) {
+    if (!scan || !scan->ls) return -1;
+    return static_cast<int>(scan->ls->shot_limiting());
+}
+
+int ouster_lidar_scan_thermal_shutdown_status(const ouster_lidar_scan_t* scan) {
+    if (!scan || !scan->ls) return -1;
+    return static_cast<int>(scan->ls->thermal_shutdown());
+}
+
+int ouster_lidar_scan_complete(const ouster_lidar_scan_t* scan) {
+    if (!scan || !scan->ls) return -1;
+    try {
+        return scan->ls->complete() ? 1 : 0;
+    } catch (...) {
+        return -1;
+    }
+}
                                     size_t* out_count) {
     if (!scan || !scan->ls || !field_name || !out_buf) return -3;
     if (!scan->ls->has_field(field_name)) return -1;


### PR DESCRIPTION
## Related Issues & PRs

## Summary of Changes

Minimal C and C# bindings for ouster-sdk to get the sensor accessible in these languages

## Validation
Clone the repository with this branch:

### Building the C wrapper library
Run the following build command, note the `BUILD_C_WRAPPER` flag:
```bash
cmake -DCMAKE_TOOLCHAIN_FILE=<PATH/TO/VCPKG> \
    -DVCPKG_MANIFEST_MODE=ON  \
    -DBUILD_C_WRAPPER=ON      \
    -DBUILD_EXAMPLES=ON       \
    -DBUILD_PCAP=ON           \
    -DBUILD_OSF=ON            \
    -DBUILD_VIZ=ON            \
    -DBUILD_SHARED_LIBRARY=ON \
    -DCMAKE_CXX_STANDARD=14   \
    -Bbuild ./ouster-sdk
```
This should build the **ouster_c** library and the two provided examples.
You can run any of the two examples as follows:
* c_client_example
```bash
./build/examples/c_client_example <sensor_url> <lidar_port> <imu_port>
```
* c_scan_source_example
``bash
./build/examples/c_client_example <sensor_url>
```
### Building the C# wrapper library and examples
Make sure you have a dotnet already installed:
```bash
dotnet build ouster-sdk/c_sharp
```
This should be the library and the included example, to execute the example simply execute the command:
```bash
dotnet run --project ouster-sdk/c_sharp -- <sensor_url>
```