### PR TITLE
Fix RingBuffer::push() loading wrong atomic index

### DIFF
--- a/ouster_client/include/ouster/impl/ring_buffer.h
+++ b/ouster_client/include/ouster/impl/ring_buffer.h
@@ -148,7 +148,7 @@ class RingBuffer {
         if (full()) {
             throw std::overflow_error("pushed a full ring buffer");
         }
-        size_t write_idx = r_idx_.load();
+        size_t write_idx = w_idx_.load();
         // atomic increment modulo
         while (!w_idx_.compare_exchange_strong(write_idx,
                                                (write_idx + 1) % _capacity())) {


### PR DESCRIPTION
## Summary

`RingBuffer::push()` in `ouster_client/include/ouster/impl/ring_buffer.h` loads `r_idx_` (the read index) instead of `w_idx_` (the write index) before the `compare_exchange_strong` loop. This causes the CAS to always fail on the first iteration when the buffer is non-empty, adding an unnecessary retry on every push.

The fix changes line 151 from:
```cpp
size_t write_idx = r_idx_.load();
```
to:
```cpp
size_t write_idx = w_idx_.load();
```

This matches the correct pattern used in `pop()`, which loads `r_idx_` before its CAS loop on `r_idx_`.

## Impact

Eliminates one wasted CAS iteration per `push()` call on non-empty buffers.