### PR TITLE
Update 0.16.2 : Fix RingBuffer::push() loading wrong atomic index (#697)

### DIFF
--- a/ouster_client/include/ouster/impl/ring_buffer.h
+++ b/ouster_client/include/ouster/impl/ring_buffer.h
@@ -148,7 +148,7 @@ class RingBuffer {
         if (full()) {
             throw std::overflow_error("pushed a full ring buffer");
         }
-        size_t write_idx = r_idx_.load();
+        size_t write_idx = w_idx_.load();
         // atomic increment modulo
         while (!w_idx_.compare_exchange_strong(write_idx,
                                                (write_idx + 1) % _capacity())) {


### PR DESCRIPTION
Update 0.16.2 : Fix RingBuffer::push() loading wrong atomic index (#697)

Original PR https://github.com/ouster-lidar/ouster-sdk/commit/409b4529fcf853f656840d627e991ad869febbfc
