### PR TITLE
Add OUSTER_USE_VCPKG_IF_AVAILABLE cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ option(BUILD_EXAMPLES "Build C++ examples" OFF)
 option(OUSTER_USE_EIGEN_MAX_ALIGN_BYTES_32 "Eigen max aligned bytes." OFF)
 option(BUILD_SHARED_LIBRARY "Build shared Library." OFF)
 option(BUILD_DEBIAN_FOR_GITHUB "Build debian for github ci" OFF)
+option(OUSTER_USE_VCPKG_IF_AVAILABLE "Use VCPKG_ROOT env variable if available" ON)
 # when building as a top-level project
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/cmake/VcpkgEnv.cmake
+++ b/cmake/VcpkgEnv.cmake
@@ -2,15 +2,15 @@
 # - must include() this before project() in CMakeLists.txt
 # https://vcpkg.readthedocs.io/en/latest/users/integration/
 
-# set toolchain file if VCPKG_ROOT is defind
-if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+# set toolchain file if VCPKG_ROOT is defined, and OUSTER_USE_VCPKG_IF_AVAILABLE is ON
+if(OUSTER_USE_VCPKG_IF_AVAILABLE AND DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   message(STATUS "Using CMAKE_TOOLCHAIN_FILE from env VCPKG_ROOT: $ENV{VCPKG_ROOT}")
   set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
     CACHE STRING "The CMake toolchain file")
 endif()
 
 # set VCPKG_TARGET_TRIPLET from corresponding env variable
-if(DEFINED ENV{VCPKG_TARGET_TRIPLET} AND NOT DEFINED VCPKG_TARGET_TRIPLET)
+if(OUSTER_USE_VCPKG_IF_AVAILABLE AND DEFINED ENV{VCPKG_TARGET_TRIPLET} AND NOT DEFINED VCPKG_TARGET_TRIPLET)
   message(STATUS "Using VCPKG_TARGET_TRIPLET from env: $ENV{VCPKG_TARGET_TRIPLET}")
   set(VCPKG_TARGET_TRIPLET "$ENV{VCPKG_TARGET_TRIPLET}"
     CACHE STRING "Triplet used for vcpkg build")


### PR DESCRIPTION
## Related Issues & PRs

See https://github.com/RoboStack/ros-jazzy/pull/212 .

## Summary of Changes

In some cases, even if `VCPKG_ROOT` env variable is defined, we do not want to use vcpkg's CMAKE_TOOLCHAIN_FILE. This for example happens on GitHub Actions Windows default images (that set VCPKG_ROOT) when using another package manager to install the dependencies used to build ouster (in  https://github.com/RoboStack/ros-jazzy/pull/212 for example, were we use conda to install the Windows package dependendecies).

To support this use case without breaking any existing use case, this PR adds a `OUSTER_USE_VCPKG_IF_AVAILABLE` CMake option (that by default is ON) that if set to `OFF`, disable the automatic setting of CMAKE_TOOLCHAIN_FILE based on the `VCPKG_ROOT` env variable.

## Validation

I tested the patch in https://github.com/RoboStack/ros-jazzy/pull/212, by explicitly setting the option `OUSTER_USE_VCPKG_IF_AVAILABLE` to OFF.